### PR TITLE
Endpoints for speed limits and unpinning files

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ SKYNET_DB_HOST="localhost"
 SKYNET_DB_PORT="27017"
 SKYNET_DB_USER="username"
 SKYNET_DB_PASS="password"
-SKYNET_ACCOUNTS_PORT=3000
 COOKIE_DOMAIN="siasky.net"
 COOKIE_HASH_KEY="any thirty-two byte string is ok"
 COOKIE_ENC_KEY="any thirty-two byte string is ok"

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -95,6 +95,16 @@ func (api *API) userHandler(w http.ResponseWriter, req *http.Request, _ httprout
 	api.WriteJSON(w, u)
 }
 
+// userLimitsHandler returns the speed limits which apply for this user.
+func (api *API) userLimitsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	u := api.userFromRequest(req)
+	if u == nil {
+		api.WriteJSON(w, database.SpeedLimits[database.TierAnonymous])
+		return
+	}
+	api.WriteJSON(w, database.SpeedLimits[u.Tier])
+}
+
 // userStatsHandler returns statistics about an existing user.
 func (api *API) userStatsHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	sub, _, _, err := jwt.TokenFromContext(req.Context())

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -447,15 +447,15 @@ func (api *API) skylinkDeleteHandler(w http.ResponseWriter, req *http.Request, p
 		api.WriteError(w, err, http.StatusBadRequest)
 		return
 	}
+	if err != nil {
+		api.WriteError(w, err, http.StatusInternalServerError)
+		return
+	}
 	_, err = api.staticDB.UnpinUploads(req.Context(), *skylink, *u)
 	if err != nil {
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return
 	}
-	//_, remaining, err := api.staticDB.UploadsBySkylink(req.Context(), *skylink, 0, 1)
-	//if remaining == 0 {
-	//// TODO call siad to unpin this
-	//}
 	api.WriteSuccess(w)
 }
 

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -264,9 +264,9 @@ func (api *API) userUploadDeleteHandler(w http.ResponseWriter, req *http.Request
 	api.WriteSuccess(w)
 	// Now that we've returned results to the caller, we can take care of some
 	// administrative details, such as user's quotas check.
-	// Nota that this call is not affected by the request's context, so we use
+	// Note that this call is not affected by the request's context, so we use
 	// a separate one.
-	api.checkUserQuotas(context.Background(), u)
+	go api.checkUserQuotas(context.Background(), u)
 }
 
 // userDownloadsHandler returns all downloads made by the current user.
@@ -348,9 +348,9 @@ func (api *API) trackUploadHandler(w http.ResponseWriter, req *http.Request, ps 
 	api.WriteSuccess(w)
 	// Now that we've returned results to the caller, we can take care of some
 	// administrative details, such as user's quotas check.
-	// Nota that this call is not affected by the request's context, so we use
+	// Note that this call is not affected by the request's context, so we use
 	// a separate one.
-	api.checkUserQuotas(context.Background(), u)
+	go api.checkUserQuotas(context.Background(), u)
 }
 
 // trackDownloadHandler registers a new download in the system.
@@ -494,9 +494,9 @@ func (api *API) skylinkDeleteHandler(w http.ResponseWriter, req *http.Request, p
 	api.WriteSuccess(w)
 	// Now that we've returned results to the caller, we can take care of some
 	// administrative details, such as user's quotas check.
-	// Nota that this call is not affected by the request's context, so we use
+	// Note that this call is not affected by the request's context, so we use
 	// a separate one.
-	api.checkUserQuotas(context.Background(), u)
+	go api.checkUserQuotas(context.Background(), u)
 }
 
 // checkUserQuotas compares the resources consumed by the user to their quotas

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -451,7 +451,7 @@ func (api *API) skylinkDeleteHandler(w http.ResponseWriter, req *http.Request, p
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return
 	}
-	_, err = api.staticDB.UnpinUploads(req.Context(), *skylink, *u)
+	_, err = api.staticDB.UnpinUpload(req.Context(), *skylink, *u)
 	if err != nil {
 		api.WriteError(w, err, http.StatusInternalServerError)
 		return

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -341,8 +341,7 @@ func (api *API) trackUploadHandler(w http.ResponseWriter, req *http.Request, ps 
 		// Queue the skylink to have its meta data fetched and updated in the DB.
 		go func() {
 			api.staticMF.Queue <- metafetcher.Message{
-				UploaderID: u.ID,
-				SkylinkID:  skylink.ID,
+				SkylinkID: skylink.ID,
 			}
 		}()
 	}

--- a/api/routes.go
+++ b/api/routes.go
@@ -28,6 +28,7 @@ func (api *API) buildHTTPRoutes() {
 	api.staticRouter.GET("/user/limits", api.noValidate(api.userLimitsHandler))
 	api.staticRouter.GET("/user/stats", api.validate(api.userStatsHandler))
 	api.staticRouter.GET("/user/uploads", api.validate(api.userUploadsHandler))
+	api.staticRouter.DELETE("/user/uploads/:uploadId", api.validate(api.userUploadDeleteHandler))
 	api.staticRouter.GET("/user/downloads", api.validate(api.userDownloadsHandler))
 
 	api.staticRouter.DELETE("/skylink/:skylink", api.validate(api.skylinkDeleteHandler))

--- a/api/routes.go
+++ b/api/routes.go
@@ -15,7 +15,7 @@ import (
 
 // buildHTTPRoutes registers all HTTP routes and their handlers.
 func (api *API) buildHTTPRoutes() {
-	api.staticRouter.POST("/login", api.loginHandler)
+	api.staticRouter.POST("/login", api.noValidate(api.loginHandler))
 	api.staticRouter.POST("/logout", api.validate(api.logoutHandler))
 
 	api.staticRouter.POST("/track/upload/:skylink", api.validate(api.trackUploadHandler))
@@ -25,21 +25,30 @@ func (api *API) buildHTTPRoutes() {
 
 	api.staticRouter.GET("/user", api.validate(api.userHandler))
 	api.staticRouter.PUT("/user", api.validate(api.userPutHandler))
-	api.staticRouter.GET("/user/limits", api.userLimitsHandler)
+	api.staticRouter.GET("/user/limits", api.noValidate(api.userLimitsHandler))
 	api.staticRouter.GET("/user/stats", api.validate(api.userStatsHandler))
 	api.staticRouter.GET("/user/uploads", api.validate(api.userUploadsHandler))
 	api.staticRouter.GET("/user/downloads", api.validate(api.userDownloadsHandler))
 
 	api.staticRouter.DELETE("/skylink/:skylink", api.validate(api.skylinkDeleteHandler))
 
-	api.staticRouter.POST("/stripe/webhook", api.stripeWebhookHandler)
-	api.staticRouter.GET("/stripe/prices", api.stripePricesHandler)
+	api.staticRouter.POST("/stripe/webhook", api.noValidate(api.stripeWebhookHandler))
+	api.staticRouter.GET("/stripe/prices", api.noValidate(api.stripePricesHandler))
+}
+
+// noValidate is a pass-through method used for decorating the request and
+// logging relevant data.
+func (api *API) noValidate(h httprouter.Handle) httprouter.Handle {
+	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
+		api.logRequest(req)
+		h(w, req, ps)
+	}
 }
 
 // validate ensures that the user making the request has logged in.
 func (api *API) validate(h httprouter.Handle) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
-		api.staticLogger.Tracef("Processing request: %+v", req)
+		api.logRequest(req)
 		tokenStr, err := tokenFromRequest(req)
 		if err != nil {
 			api.staticLogger.Traceln("Error fetching token from request:", err)
@@ -56,6 +65,14 @@ func (api *API) validate(h httprouter.Handle) httprouter.Handle {
 		ctx := jwt.ContextWithToken(req.Context(), token)
 		h(w, req.WithContext(ctx), ps)
 	}
+}
+
+// logRequest logs information about the current request.
+func (api *API) logRequest(r *http.Request) {
+	hasAuth := strings.HasPrefix(r.Header.Get("Authorization"), "Bearer")
+	c, err := r.Cookie(CookieName)
+	hasCookie := err == nil && c != nil
+	api.staticLogger.Tracef("Processing request: %v %v, Auth: %v, Skynet Cookie: %v, Referrer: %v, Host: %v, RemoreAddr: %v", r.Method, r.URL, hasAuth, hasCookie, r.Referer(), r.Host, r.RemoteAddr)
 }
 
 // tokenFromRequest extracts the JWT token from the request and returns it.

--- a/api/routes.go
+++ b/api/routes.go
@@ -26,6 +26,8 @@ func (api *API) buildHTTPRoutes() {
 	api.staticRouter.GET("/user/uploads", api.validate(api.userUploadsHandler))
 	api.staticRouter.GET("/user/downloads", api.validate(api.userDownloadsHandler))
 
+	api.staticRouter.DELETE("/skylink/:skylink", api.validate(api.skylinkDeleteHandler))
+
 	api.staticRouter.POST("/stripe/webhook", api.stripeWebhookHandler)
 	api.staticRouter.GET("/stripe/prices", api.stripePricesHandler)
 }

--- a/api/routes.go
+++ b/api/routes.go
@@ -73,7 +73,7 @@ func (api *API) logRequest(r *http.Request) {
 	hasAuth := strings.HasPrefix(r.Header.Get("Authorization"), "Bearer")
 	c, err := r.Cookie(CookieName)
 	hasCookie := err == nil && c != nil
-	api.staticLogger.Tracef("Processing request: %v %v, Auth: %v, Skynet Cookie: %v, Referrer: %v, Host: %v, RemoreAddr: %v", r.Method, r.URL, hasAuth, hasCookie, r.Referer(), r.Host, r.RemoteAddr)
+	api.staticLogger.Tracef("Processing request: %v %v, Auth: %v, Skynet Cookie: %v, Referer: %v, Host: %v, RemoreAddr: %v", r.Method, r.URL, hasAuth, hasCookie, r.Referer(), r.Host, r.RemoteAddr)
 }
 
 // tokenFromRequest extracts the JWT token from the request and returns it.
@@ -117,7 +117,7 @@ func (api *API) userFromRequest(r *http.Request) *database.User {
 	}
 	claims := token.Claims.(jwt2.MapClaims)
 	if reflect.ValueOf(claims["sub"]).Kind() != reflect.String {
-		err = errors.New("the token does not contain the sub we expect")
+		return nil
 	}
 	u, err := api.staticDB.UserBySub(r.Context(), claims["sub"].(string), false)
 	if err != nil {

--- a/api/stripe.go
+++ b/api/stripe.go
@@ -21,6 +21,11 @@ import (
 	"gitlab.com/NebulousLabs/errors"
 )
 
+const (
+	// MaxBodyBytes defines the maximum length of a webhook call's request body.
+	MaxBodyBytes = int64(65536)
+)
+
 var (
 	// StripeTestMode tells us whether to use Stripe's test mode or prod mode
 	// plan and price ids.
@@ -182,12 +187,11 @@ func (api *API) stripePricesHandler(w http.ResponseWriter, req *http.Request, _ 
 // readStripeEvent reads the event from the request body and verifies its
 // signature.
 func readStripeEvent(w http.ResponseWriter, req *http.Request) (*stripe.Event, int, error) {
-	const MaxBodyBytes = int64(65536)
 	req.Body = http.MaxBytesReader(w, req.Body, MaxBodyBytes)
 	payload, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		err = errors.AddContext(err, "error reading request body")
-		return nil, http.StatusServiceUnavailable, err
+		return nil, http.StatusBadRequest, err
 	}
 	// Read the event and verify its signature.
 	event, err := webhook.ConstructEvent(payload, req.Header.Get("Stripe-Signature"), os.Getenv("STRIPE_WEBHOOK_SECRET"))
@@ -207,33 +211,34 @@ func (api *API) processStripeSub(ctx context.Context, s *stripe.Subscription) er
 		Customer: s.Customer.ID,
 		Status:   string(stripe.SubscriptionStatusActive),
 	})
+	// TODO Allow multiple stripe ids per user?
 	u, err := api.staticDB.UserByStripeID(ctx, s.Customer.ID)
 	if err != nil {
 		return errors.AddContext(err, "failed to fetch user from DB based on subscription info")
 	}
-	// Set the default values.
-	u.Tier = database.TierFree
-	u.SubscribedUntil = time.Time{}
-	u.SubscriptionStatus = ""
-	u.SubscriptionCancelAt = time.Time{}
-	u.SubscriptionCancelAtPeriodEnd = false
-	var latestCreated time.Time
-	var latestSub string
 	// Pick the latest active plan and set the user's tier based on that.
 	subs := it.SubscriptionList().Data
+	var mostRecentSub *stripe.Subscription
 	for _, subsc := range subs {
-		created := time.Unix(subsc.Created, 0).UTC()
-		if created.After(latestCreated) {
-			latestCreated = created
-			latestSub = subsc.ID
-			// It seems weird that the Plan.ID is actually a price id but this
-			// is what we get from Stripe.
-			u.Tier = stripePrices()[subsc.Plan.ID]
-			u.SubscribedUntil = time.Unix(subsc.CurrentPeriodEnd, 0).UTC()
-			u.SubscriptionStatus = string(subsc.Status)
-			u.SubscriptionCancelAt = time.Unix(subsc.CancelAt, 0)
-			u.SubscriptionCancelAtPeriodEnd = subsc.CancelAtPeriodEnd
+		if mostRecentSub == nil || mostRecentSub.Created < subsc.Created {
+			mostRecentSub = subsc
 		}
+	}
+	if mostRecentSub == nil {
+		// No active sub, set the default values.
+		u.Tier = database.TierFree
+		u.SubscribedUntil = time.Time{}
+		u.SubscriptionStatus = ""
+		u.SubscriptionCancelAt = time.Time{}
+		u.SubscriptionCancelAtPeriodEnd = false
+	} else {
+		// It seems weird that the Plan.ID is actually a price id but this
+		// is what we get from Stripe.
+		u.Tier = stripePrices()[mostRecentSub.Plan.ID]
+		u.SubscribedUntil = time.Unix(mostRecentSub.CurrentPeriodEnd, 0).UTC()
+		u.SubscriptionStatus = string(mostRecentSub.Status)
+		u.SubscriptionCancelAt = time.Unix(mostRecentSub.CancelAt, 0)
+		u.SubscriptionCancelAtPeriodEnd = mostRecentSub.CancelAtPeriodEnd
 	}
 	// Cancel all subs aside from the latest one.
 	p := stripe.SubscriptionCancelParams{
@@ -244,18 +249,21 @@ func (api *API) processStripeSub(ctx context.Context, s *stripe.Subscription) er
 		Prorate:    &True,
 	}
 	for _, subsc := range subs {
-		if subsc == nil || subsc.ID == latestSub {
+		if subsc == nil || (mostRecentSub != nil && subsc.ID == mostRecentSub.ID) {
 			continue
 		}
 		subsc, err = sub.Cancel(subsc.ID, &p)
 		if err != nil {
 			api.staticLogger.Warnf("Failed to cancel sub with id %s for user %s with Stripe customer id %s. Error: %s", subsc.ID, u.ID.Hex(), s.Customer.ID, err.Error())
 		} else {
-			api.staticLogger.Tracef("Successfullu cancelled sub with id %s for user %s with Stripe customer id %s.", subsc.ID, u.ID.Hex(), s.Customer.ID)
+			api.staticLogger.Tracef("Successfully cancelled sub with id %s for user %s with Stripe customer id %s.", subsc.ID, u.ID.Hex(), s.Customer.ID)
 		}
 	}
-	api.staticLogger.Tracef("Subscribed user id %s, tier %d, until %s.", u.ID, u.Tier, u.SubscribedUntil.String())
-	return api.staticDB.UserSave(ctx, u)
+	err = api.staticDB.UserSave(ctx, u)
+	if err == nil {
+		api.staticLogger.Tracef("Subscribed user id %s, tier %d, until %s.", u.ID, u.Tier, u.SubscribedUntil.String())
+	}
+	return err
 }
 
 // assignTier sets the user's account to the given tier, both on Stripe's side

--- a/api/stripe.go
+++ b/api/stripe.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -155,8 +154,7 @@ func (api *API) stripeWebhookHandler(w http.ResponseWriter, req *http.Request, _
 }
 
 // stripePricesHandler returns a list of plans and prices.
-func (api *API) stripePricesHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	api.staticLogger.Tracef("Processing request: %+v", req)
+func (api *API) stripePricesHandler(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	var sPrices []stripePrice
 	params := &stripe.PriceListParams{Active: &True}
 	params.AddExpand("data.product")
@@ -164,7 +162,6 @@ func (api *API) stripePricesHandler(w http.ResponseWriter, req *http.Request, _ 
 	i := price.List(params)
 	for i.Next() {
 		p := i.Price()
-		fmt.Printf("price: %+v\n", p)
 		if !p.Active {
 			continue
 		}

--- a/api/stripe.go
+++ b/api/stripe.go
@@ -150,6 +150,9 @@ func (api *API) stripePricesHandler(w http.ResponseWriter, req *http.Request, _ 
 	i := price.List(params)
 	for i.Next() {
 		p := i.Price()
+		if !p.Active {
+			continue
+		}
 		sp := stripePrice{
 			ID:          p.ID,
 			Name:        p.Product.Name,

--- a/api/stripe.go
+++ b/api/stripe.go
@@ -217,7 +217,7 @@ func (api *API) processStripeSub(ctx context.Context, s *stripe.Subscription) er
 	subs := it.SubscriptionList().Data
 	var mostRecentSub *stripe.Subscription
 	for _, subsc := range subs {
-		if mostRecentSub == nil || mostRecentSub.Created < subsc.Created {
+		if mostRecentSub == nil || subsc.Created > mostRecentSub.Created {
 			mostRecentSub = subsc
 		}
 	}

--- a/database/skylink_test.go
+++ b/database/skylink_test.go
@@ -2,8 +2,9 @@ package database
 
 import "testing"
 
-// TestValidateSkylink ensures validateSkylink properly returns the skylink hash
-func TestValidateSkylink(t *testing.T) {
+// TestExtractSkylinkHash ensures ExtractSkylinkHash properly returns the
+// skylink hash.
+func TestExtractSkylinkHash(t *testing.T) {
 	tests := []struct {
 		in    string
 		out   string
@@ -27,7 +28,7 @@ func TestValidateSkylink(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		out, err := validateSkylink(tt.in)
+		out, err := ExtractSkylinkHash(tt.in)
 		if tt.valid && err != nil {
 			t.Fatalf("expected %s to be valid, got error %s", tt.in, err)
 		}

--- a/database/upload.go
+++ b/database/upload.go
@@ -88,9 +88,9 @@ func (db *DB) UploadsBySkylink(ctx context.Context, skylink Skylink, offset, pag
 	return db.uploadsBy(ctx, matchStage, offset, pageSize)
 }
 
-// UnpinUploads unpins all uploads of this skylink by this user. Returns the
-// number of unpinned uploads.
-func (db *DB) UnpinUploads(ctx context.Context, skylink Skylink, user User) (int64, error) {
+// UnpinUpload unpins one of the uploads of this skylink by this user. Returns
+// the number of unpinned uploads.
+func (db *DB) UnpinUpload(ctx context.Context, skylink Skylink, user User) (int64, error) {
 	if skylink.ID.IsZero() {
 		return 0, errors.New("invalid skylink")
 	}
@@ -100,9 +100,10 @@ func (db *DB) UnpinUploads(ctx context.Context, skylink Skylink, user User) (int
 	filter := bson.D{
 		{"skylink_id", skylink.ID},
 		{"user_id", user.ID},
+		{"unpinned", false},
 	}
 	update := bson.M{"$set": bson.M{"unpinned": true}}
-	ur, err := db.staticUploads.UpdateMany(ctx, filter, update)
+	ur, err := db.staticUploads.UpdateOne(ctx, filter, update)
 	if err != nil {
 		return 0, err
 	}

--- a/database/upload.go
+++ b/database/upload.go
@@ -23,11 +23,12 @@ type Upload struct {
 // UploadResponseDTO is the representation of an upload we send as response to
 // the caller.
 type UploadResponseDTO struct {
-	ID        string    `bson:"_id" json:"id"`
-	Skylink   string    `bson:"skylink" json:"skylink"`
-	Name      string    `bson:"name" json:"name"`
-	Size      int64     `bson:"size" json:"size"`
-	Timestamp time.Time `bson:"timestamp" json:"uploadedOn"`
+	ID         string    `bson:"_id" json:"id"`
+	Skylink    string    `bson:"skylink" json:"skylink"`
+	Name       string    `bson:"name" json:"name"`
+	Size       int64     `bson:"size" json:"size"`
+	RawStorage int64     `bson:"raw_storage" json:"rawStorage"`
+	Timestamp  time.Time `bson:"timestamp" json:"uploadedOn"`
 }
 
 // UploadsResponseDTO defines the final format of our response to the caller.
@@ -152,7 +153,7 @@ func (db *DB) uploadsBy(ctx context.Context, matchStage bson.D, offset, pageSize
 		return nil, 0, err
 	}
 	for ix := range uploads {
-		uploads[ix].Size = skynet.StorageUsed(uploads[ix].Size)
+		uploads[ix].RawStorage = skynet.RawStorageUsed(uploads[ix].Size)
 	}
 	return uploads, int(cnt), nil
 }

--- a/database/upload.go
+++ b/database/upload.go
@@ -89,9 +89,35 @@ func (db *DB) UploadsBySkylink(ctx context.Context, skylink Skylink, offset, pag
 	return db.uploadsBy(ctx, matchStage, offset, pageSize)
 }
 
-// UnpinUpload unpins one of the uploads of this skylink by this user. Returns
+// UnpinUpload unpins a single upload by this user. Returns the number of
+// unpinned uploads.
+func (db *DB) UnpinUpload(ctx context.Context, uploadId string, user User) (int64, error) {
+	if uploadId == "" {
+		return 0, errors.New("invalid skylink")
+	}
+	uid, err := primitive.ObjectIDFromHex(uploadId)
+	if err != nil {
+		return 0, errors.New("invalid upload id")
+	}
+	if user.ID.IsZero() {
+		return 0, errors.New("invalid user")
+	}
+	filter := bson.D{
+		{"_id", uid},
+		{"user_id", user.ID},
+		{"unpinned", false},
+	}
+	update := bson.M{"$set": bson.M{"unpinned": true}}
+	ur, err := db.staticUploads.UpdateOne(ctx, filter, update)
+	if err != nil {
+		return 0, err
+	}
+	return ur.ModifiedCount, nil
+}
+
+// UnpinUploads unpins all uploads of this skylink by this user. Returns
 // the number of unpinned uploads.
-func (db *DB) UnpinUpload(ctx context.Context, skylink Skylink, user User) (int64, error) {
+func (db *DB) UnpinUploads(ctx context.Context, skylink Skylink, user User) (int64, error) {
 	if skylink.ID.IsZero() {
 		return 0, errors.New("invalid skylink")
 	}
@@ -104,7 +130,7 @@ func (db *DB) UnpinUpload(ctx context.Context, skylink Skylink, user User) (int6
 		{"unpinned", false},
 	}
 	update := bson.M{"$set": bson.M{"unpinned": true}}
-	ur, err := db.staticUploads.UpdateOne(ctx, filter, update)
+	ur, err := db.staticUploads.UpdateMany(ctx, filter, update)
 	if err != nil {
 		return 0, err
 	}

--- a/database/user.go
+++ b/database/user.go
@@ -349,6 +349,7 @@ func (db *DB) userStats(ctx context.Context, user User) (*UserStats, error) {
 func (db *DB) userUploadStats(ctx context.Context, id primitive.ObjectID, monthStart time.Time) (count int, totalSize int64, storageUsed int64, totalBandwidth int64, err error) {
 	matchStage := bson.D{{"$match", bson.D{
 		{"user_id", id},
+		{"unpinned", false},
 		{"timestamp", bson.D{{"$gt", monthStart}}},
 	}}}
 	lookupStage := bson.D{

--- a/database/user.go
+++ b/database/user.go
@@ -599,6 +599,12 @@ func monthStart(subscribedUntil time.Time) time.Time {
 	// the month. If they were never subscribed we use Jan 1st 1970 for
 	// SubscribedUntil.
 	daysDelta := subscribedUntil.Day() - now.Day()
-	d := now.AddDate(0, -1, daysDelta)
+	monthsDelta := 0
+	if daysDelta > 0 {
+		// The end of sub day is after the current date, so the start of month
+		// is in the previous month.
+		monthsDelta = -1
+	}
+	d := now.AddDate(0, monthsDelta, daysDelta)
 	return time.Date(d.Year(), d.Month(), d.Day(), 0, 0, 0, 0, time.UTC)
 }

--- a/database/user.go
+++ b/database/user.go
@@ -42,6 +42,7 @@ var (
 	// False is a helper for when we need to pass a *bool to MongoDB.
 	False = false
 	// SpeedLimits defines the speed limits for each tier.
+	// Registry delay is in ms.
 	SpeedLimits = map[int]TierLimits{
 		TierAnonymous: {
 			Upload:   5 * bpsToBytesPerSecond,
@@ -56,17 +57,17 @@ var (
 		TierPremium5: {
 			Upload:   20 * bpsToBytesPerSecond,
 			Download: 80 * bpsToBytesPerSecond,
-			Registry: 60,
+			Registry: 0,
 		},
 		TierPremium20: {
 			Upload:   40 * bpsToBytesPerSecond,
 			Download: 160 * bpsToBytesPerSecond,
-			Registry: 30,
+			Registry: 0,
 		},
 		TierPremium80: {
 			Upload:   80 * bpsToBytesPerSecond,
 			Download: 320 * bpsToBytesPerSecond,
-			Registry: 15,
+			Registry: 0,
 		},
 	}
 )

--- a/database/user.go
+++ b/database/user.go
@@ -54,34 +54,41 @@ var (
 		TierAnonymous: {
 			UploadBandwidth:   5 * mbpsToBytesPerSecond,
 			DownloadBandwidth: 20 * mbpsToBytesPerSecond,
+			MaxUploadSize:     1 * skynet.GiB,
+			MaxNumberUploads:  0,
 			RegistryDelay:     250,
+			Storage:           0,
 		},
 		TierFree: {
 			UploadBandwidth:   10 * mbpsToBytesPerSecond,
 			DownloadBandwidth: 40 * mbpsToBytesPerSecond,
-			RegistryDelay:     125,
+			MaxUploadSize:     1 * skynet.GiB,
 			MaxNumberUploads:  0.1 * filesAllowedPerTB,
+			RegistryDelay:     125,
 			Storage:           100 * skynet.GiB,
 		},
 		TierPremium5: {
 			UploadBandwidth:   20 * mbpsToBytesPerSecond,
 			DownloadBandwidth: 80 * mbpsToBytesPerSecond,
-			RegistryDelay:     0,
+			MaxUploadSize:     1 * skynet.GiB,
 			MaxNumberUploads:  1 * filesAllowedPerTB,
+			RegistryDelay:     0,
 			Storage:           1 * skynet.TiB,
 		},
 		TierPremium20: {
 			UploadBandwidth:   40 * mbpsToBytesPerSecond,
 			DownloadBandwidth: 160 * mbpsToBytesPerSecond,
-			RegistryDelay:     0,
+			MaxUploadSize:     1 * skynet.GiB,
 			MaxNumberUploads:  4 * filesAllowedPerTB,
+			RegistryDelay:     0,
 			Storage:           4 * skynet.TiB,
 		},
 		TierPremium80: {
 			UploadBandwidth:   80 * mbpsToBytesPerSecond,
 			DownloadBandwidth: 320 * mbpsToBytesPerSecond,
-			RegistryDelay:     0,
+			MaxUploadSize:     1 * skynet.GiB,
 			MaxNumberUploads:  20 * filesAllowedPerTB,
+			RegistryDelay:     0,
 			Storage:           20 * skynet.TiB,
 		},
 	}
@@ -106,7 +113,7 @@ type (
 	}
 	// UserStats contains statistical information about the user.
 	UserStats struct {
-		RawStorageUsed     int64 `json:"storageUsed"`
+		RawStorageUsed     int64 `json:"rawStorageUsed"`
 		NumRegReads        int64 `json:"numRegReads"`
 		NumRegWrites       int64 `json:"numRegWrites"`
 		NumUploads         int   `json:"numUploads"`
@@ -121,11 +128,12 @@ type (
 	// TierLimits defines the speed limits imposed on the user based on their
 	// tier.
 	TierLimits struct {
-		UploadBandwidth   int   `json:"upload"`   // bytes per second
-		DownloadBandwidth int   `json:"download"` // bytes per second
+		UploadBandwidth   int   `json:"upload"`        // bytes per second
+		DownloadBandwidth int   `json:"download"`      // bytes per second
+		MaxUploadSize     int64 `json:"maxUploadSize"` // the max size of a single upload in bytes
+		MaxNumberUploads  int   `json:"-"`
 		RegistryDelay     int   `json:"registry"` // ms delay
-		MaxNumberUploads  int   `json:"maxNumberUploads"`
-		Storage           int64 `json:"storage"`
+		Storage           int64 `json:"-"`
 	}
 )
 

--- a/database/user.go
+++ b/database/user.go
@@ -40,7 +40,7 @@ const (
 	// on users. While we define it per TB, we impose it based on their entire
 	// quota, so an Extreme user will be able to upload up to 400_000 files
 	// before being hit with a speed limit.
-	filesAllowedPerTB = 20_000
+	filesAllowedPerTB = 25_000
 )
 
 var (
@@ -48,9 +48,9 @@ var (
 	True = true
 	// False is a helper for when we need to pass a *bool to MongoDB.
 	False = false
-	// SpeedLimits defines the speed limits for each tier.
+	// UserLimits defines the speed limits for each tier.
 	// RegistryDelay delay is in ms.
-	SpeedLimits = map[int]TierLimits{
+	UserLimits = map[int]TierLimits{
 		TierAnonymous: {
 			UploadBandwidth:   5 * mbpsToBytesPerSecond,
 			DownloadBandwidth: 20 * mbpsToBytesPerSecond,

--- a/database/user.go
+++ b/database/user.go
@@ -571,7 +571,7 @@ func (db *DB) userRegistryWriteStats(ctx context.Context, userId primitive.Objec
 	if err != nil {
 		return 0, 0, errors.AddContext(err, "failed to fetch registry write bandwidth")
 	}
-	return writes, writes * skynet.PriceBandwidthRegistryWrite, nil
+	return writes, writes * skynet.CostBandwidthRegistryWrite, nil
 }
 
 // userRegistryReadsStats reports the number of registry reads by the user and
@@ -585,7 +585,7 @@ func (db *DB) userRegistryReadStats(ctx context.Context, userId primitive.Object
 	if err != nil {
 		return 0, 0, errors.AddContext(err, "failed to fetch registry read bandwidth")
 	}
-	return reads, reads * skynet.PriceBandwidthRegistryRead, nil
+	return reads, reads * skynet.CostBandwidthRegistryRead, nil
 }
 
 // monthStart returns the start of the user's subscription month.

--- a/database/user.go
+++ b/database/user.go
@@ -110,6 +110,7 @@ type (
 		SubscriptionCancelAt          time.Time          `bson:"subscription_cancel_at" json:"subscriptionCancelAt"`
 		SubscriptionCancelAtPeriodEnd bool               `bson:"subscription_cancel_at_period_end" json:"subscriptionCancelAtPeriodEnd"`
 		StripeId                      string             `bson:"stripe_id" json:"stripeCustomerId"`
+		QuotaExceeded                 bool               `bson:"quota_exceeded" json:"quotaExceeded"`
 	}
 	// UserStats contains statistical information about the user.
 	UserStats struct {

--- a/database/user_test.go
+++ b/database/user_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-//TestMonthStart ensures we calculate the start of the subscription month
+// TestMonthStart ensures we calculate the start of the subscription month
 // correctly.
 func TestMonthStart(t *testing.T) {
 	now := time.Now()

--- a/database/user_test.go
+++ b/database/user_test.go
@@ -1,0 +1,42 @@
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+//TestMonthStart ensures we calculate the start of the subscription month
+// correctly.
+func TestMonthStart(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		subUntil     time.Time
+		startOfMonth time.Time
+	}{
+		{
+			// If the monthly sub cycle reset yesterday, expect the start of
+			// month to also be yesterday.
+			subUntil:     time.Date(2020, 1, now.Day()-1, 3, 4, 5, 6, time.UTC),
+			startOfMonth: time.Date(now.Year(), now.Month(), now.Day()-1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// If the monthly sub cycle resets today, expect the start of
+			// month to also be today.
+			subUntil:     time.Date(2020, 1, now.Day(), 3, 4, 5, 6, time.UTC),
+			startOfMonth: time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC),
+		},
+		{
+			// If the monthly sub cycle resets tomorrow, expect the start of
+			// month to be tomorrows date but a month back.
+			subUntil:     time.Date(2020, 1, now.Day()+1, 3, 4, 5, 6, time.UTC),
+			startOfMonth: time.Date(now.Year(), now.Month()-1, now.Day()+1, 0, 0, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		som := monthStart(tt.subUntil)
+		if som != tt.startOfMonth {
+			t.Errorf("Expected a sub ending on %v to have startOfMonth on %v but got %v.", tt.subUntil.String(), tt.startOfMonth.String(), som.String())
+		}
+	}
+}

--- a/go.sum
+++ b/go.sum
@@ -107,13 +107,11 @@ go.mongodb.org/mongo-driver v1.4.4/go.mod h1:WcMNYLx/IlOxLe6JRJiv2uXuCz6zBLndR4S
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190422162423-af44ce270edf/go.mod h1:WFFai1msRO1wXaEeE5yQxYXgSfI8pQAWXbQop6sCtWE=
-golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5 h1:8dUaAV7K4uHsF56JQWkprecIQKdPHtR9jCHF5nB8uzc=
 golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200324143707-d3edc9973b7e/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974 h1:IX6qOQeG5uLjB/hjjwjedwfjND0hgjPMMyO1RoIXQNI=
@@ -121,7 +119,6 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190412183630-56d357773e84/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9 h1:SQFwaSi55rU7vdNs9Yr0Z324VNlrF+0wMqRXT4St8ck=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -131,7 +128,6 @@ golang.org/x/sys v0.0.0-20190403152447-81d4e9dc473e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190419153524-e8e3143a4f4a/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190422165155-953cdadca894/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2 h1:T5DasATyLQfmbTpfEXx/IOL9vfjzW6up+ZDkmHvIf2s=
 golang.org/x/sys v0.0.0-20190531175056-4c3a928424d2/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
@@ -144,7 +140,6 @@ golang.org/x/tools v0.0.0-20190329151228-23e29df326fe/go.mod h1:LCzVGOaR6xXOjkQ3
 golang.org/x/tools v0.0.0-20190416151739-9c9e1878f421/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190420181800-aa740d480789/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190531172133-b3315ee88b7d/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
-golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/jwt/jwt.go
+++ b/jwt/jwt.go
@@ -116,6 +116,7 @@ func TokenFromContext(ctx context.Context) (sub string, claims jwt.MapClaims, to
 	claims = t.Claims.(jwt.MapClaims)
 	if reflect.ValueOf(claims["sub"]).Kind() != reflect.String {
 		err = errors.New("the token does not contain the sub we expect")
+		return
 	}
 	subEntry, ok := claims["sub"]
 	if !ok {

--- a/main.go
+++ b/main.go
@@ -37,9 +37,6 @@ var (
 	// envLogLevel holds the name of the environment variable which defines the
 	// desired log level.
 	envLogLevel = "SKYNET_ACCOUNTS_LOG_LEVEL"
-	// envPort holds the name of the environment variable for the port on which
-	// this service listens.
-	envPort = "SKYNET_ACCOUNTS_PORT"
 	// envPortal holds the name of the environment variable for the portal to
 	// use to fetch skylinks.
 	envPortal = "PORTAL_URL"
@@ -78,10 +75,6 @@ func main() {
 	// Load the environment variables from the .env file.
 	// Existing variables take precedence and won't be overwritten.
 	_ = godotenv.Load()
-	port, ok := os.LookupEnv(envPort)
-	if !ok {
-		port = "3000"
-	}
 	portal, ok := os.LookupEnv(envPortal)
 	if !ok {
 		portal = defaultPortal
@@ -113,8 +106,8 @@ func main() {
 	if err != nil {
 		log.Fatal(errors.AddContext(err, "failed to build the API"))
 	}
-	logger.Info("Listening on port " + port)
-	logger.Fatal(http.ListenAndServe(":"+port, server.Router()))
+	logger.Info("Listening on port 3000")
+	logger.Fatal(http.ListenAndServe(":3000", server.Router()))
 }
 
 // logLevel returns the desires log level.

--- a/metafetcher/fetcher.go
+++ b/metafetcher/fetcher.go
@@ -21,9 +21,8 @@ const maxAttempts = 3
 // the metadata for a given skylink and then add its size to the used space of
 // a given user.
 type Message struct {
-	UploaderID primitive.ObjectID
-	SkylinkID  primitive.ObjectID
-	Attempts   uint8
+	SkylinkID primitive.ObjectID
+	Attempts  uint8
 }
 
 // MetaFetcher is a background task that listens for messages on its queue and
@@ -73,7 +72,7 @@ func (mf *MetaFetcher) processMessage(ctx context.Context, m Message) {
 	if err != nil {
 		logrus.Tracef("Failed to fetch skylink from DB. Skylink ID: %v, error: %v", m.SkylinkID, err)
 		if m.Attempts >= maxAttempts {
-			mf.logger.Debugf("Message exceeded its maximum number of attempts, dropping: %v", m)
+			mf.logger.Debugf("Message exceeded its maximum number of attempts, dropping: %v. Last error: %v.", m, err)
 			return
 		}
 		m.Attempts++
@@ -106,7 +105,7 @@ func (mf *MetaFetcher) processMessage(ctx context.Context, m Message) {
 		}
 		mf.logger.Tracef("Failed to fetch skyfile. Skylink: %s, status: %v, error: %v", sl.Skylink, statusCode, err)
 		if m.Attempts >= maxAttempts {
-			mf.logger.Debugf("Message exceeded its maximum number of attempts, dropping: %v", m)
+			mf.logger.Debugf("Message exceeded its maximum number of attempts, dropping: %v. Last error: %v.", m, err)
 			return
 		}
 		m.Attempts++

--- a/skynet/bandwidth.go
+++ b/skynet/bandwidth.go
@@ -19,15 +19,10 @@ const (
 	// using. This is not freely configurable because we need database
 	// consistency.
 	RedundancyBaseSector = 10
-	// RedundancyBaseSector describes the redundancy of regular chunks the
+	// RedundancyChunk describes the redundancy of regular chunks the
 	// portal is using. This is not freely configurable because we need database
 	// consistency.
 	RedundancyChunk = 3
-	// RedundancyAPIDivisor is the value by which we divide the raw used storage
-	// when reporting it to the user. The goal is for the user to see numbers
-	// that make sense to them while allowing us to track the raw numbers in the
-	// database.
-	RedundancyAPIDivisor = 3
 
 	// CostBandwidthRegistryWrite the bandwidth cost of a single registry write
 	CostBandwidthRegistryWrite = 5 * MiB
@@ -78,13 +73,6 @@ func RawStorageUsed(uploadSize int64) int64 {
 	baseSectorStorage := int64(CostStorageUploadBase * RedundancyBaseSector)
 	chunkStorage := numChunks(uploadSize) * CostStorageUploadIncrement * RedundancyChunk
 	return baseSectorStorage + chunkStorage
-}
-
-// StorageUsed calculates how much storage an upload with a given size actually
-// uses. This method returns user-facing values. For the raw storage value
-// use RawStorageUsed().
-func StorageUsed(uploadSize int64) int64 {
-	return RawStorageUsed(uploadSize) / RedundancyAPIDivisor
 }
 
 // numChunks returns the number of 40MB chunks a file of this size uses, beyond

--- a/skynet/bandwidth.go
+++ b/skynet/bandwidth.go
@@ -80,9 +80,7 @@ func RawStorageUsed(uploadSize int64) int64 {
 // uses. This method returns user-facing values. For the raw storage value
 // use RawStorageUsed().
 func StorageUsed(uploadSize int64) int64 {
-	baseSectorStorage := int64(PriceStorageUploadBase * RedundancyBaseSector)
-	chunkStorage := numChunks(uploadSize) * PriceStorageUploadIncrement * RedundancyChunk
-	return (baseSectorStorage + chunkStorage) / RedundancyAPIDivisor
+	return RawStorageUsed(uploadSize) / RedundancyAPIDivisor
 }
 
 // numChunks returns the number of 40MB chunks a file of this size uses, beyond

--- a/skynet/bandwidth.go
+++ b/skynet/bandwidth.go
@@ -29,35 +29,35 @@ const (
 	// database.
 	RedundancyAPIDivisor = 3
 
-	// PriceBandwidthRegistryWrite the bandwidth cost of a single registry write
-	PriceBandwidthRegistryWrite = 5 * MiB
-	// PriceBandwidthRegistryRead the bandwidth cost of a single registry read
-	PriceBandwidthRegistryRead = MiB
+	// CostBandwidthRegistryWrite the bandwidth cost of a single registry write
+	CostBandwidthRegistryWrite = 5 * MiB
+	// CostBandwidthRegistryRead the bandwidth cost of a single registry read
+	CostBandwidthRegistryRead = MiB
 
-	// PriceBandwidthUploadBase is the baseline bandwidth price for each upload.
+	// CostBandwidthUploadBase is the baseline bandwidth price for each upload.
 	// This is the cost of uploading the base sector.
-	PriceBandwidthUploadBase = 40 * MiB
-	// PriceBandwidthUploadIncrement is the bandwidth price per 40MB uploaded
+	CostBandwidthUploadBase = 40 * MiB
+	// CostBandwidthUploadIncrement is the bandwidth price per 40MB uploaded
 	// data, beyond the base sector (beyond the first 4MB). Rounded up.
-	PriceBandwidthUploadIncrement = 120 * MiB
-	// PriceBandwidthDownloadBase is the baseline bandwidth price for each Download.
-	PriceBandwidthDownloadBase = 200 * KiB
-	// PriceBandwidthDownloadIncrement is the bandwidth price per 64B. Rounded up.
-	PriceBandwidthDownloadIncrement = 64
+	CostBandwidthUploadIncrement = 120 * MiB
+	// CostBandwidthDownloadBase is the baseline bandwidth price for each Download.
+	CostBandwidthDownloadBase = 200 * KiB
+	// CostBandwidthDownloadIncrement is the bandwidth price per 64B. Rounded up.
+	CostBandwidthDownloadIncrement = 64
 
-	// PriceStorageUploadBase is the baseline storage price for each upload.
+	// CostStorageUploadBase is the baseline storage price for each upload.
 	// This is the cost of uploading the base sector.
-	PriceStorageUploadBase = 4 * MiB
-	// PriceStorageUploadIncrement is the storage price for each 40MB beyond
+	CostStorageUploadBase = 4 * MiB
+	// CostStorageUploadIncrement is the storage price for each 40MB beyond
 	// the base sector (beyond the first 4MB). Rounded up.
-	PriceStorageUploadIncrement = 40 * MiB
+	CostStorageUploadIncrement = 40 * MiB
 )
 
 // BandwidthUploadCost calculates the bandwidth cost of an upload with the given
 // size. The base sector is uploaded with 10x redundancy. Each chunk is uploaded
 // with 3x redundancy.
 func BandwidthUploadCost(size int64) int64 {
-	return PriceBandwidthUploadBase + numChunks(size)*PriceBandwidthUploadIncrement
+	return CostBandwidthUploadBase + numChunks(size)*CostBandwidthUploadIncrement
 }
 
 // BandwidthDownloadCost calculates the bandwidth cost of a download with the
@@ -67,7 +67,7 @@ func BandwidthDownloadCost(size int64) int64 {
 	if size%64 > 0 {
 		chunks++
 	}
-	return PriceBandwidthDownloadBase + chunks*PriceBandwidthDownloadIncrement
+	return CostBandwidthDownloadBase + chunks*CostBandwidthDownloadIncrement
 }
 
 // RawStorageUsed calculates how much storage an upload with a given size
@@ -75,8 +75,8 @@ func BandwidthDownloadCost(size int64) int64 {
 // the adjusted number users see. Users see adjusted numbers in order to
 // shield them from the complexity of base/chunk redundancy.
 func RawStorageUsed(uploadSize int64) int64 {
-	baseSectorStorage := int64(PriceStorageUploadBase * RedundancyBaseSector)
-	chunkStorage := numChunks(uploadSize) * PriceStorageUploadIncrement * RedundancyChunk
+	baseSectorStorage := int64(CostStorageUploadBase * RedundancyBaseSector)
+	chunkStorage := numChunks(uploadSize) * CostStorageUploadIncrement * RedundancyChunk
 	return baseSectorStorage + chunkStorage
 }
 

--- a/skynet/bandwidth.go
+++ b/skynet/bandwidth.go
@@ -5,6 +5,10 @@ const (
 	KiB = 1024
 	// MiB megabyte
 	MiB = 1024 * KiB
+	// GiB gigabyte
+	GiB = 1024 * MiB
+	// TiB terabyte
+	TiB = 1024 * GiB
 
 	// SizeBaseSector is the size of a base sector.
 	SizeBaseSector = 4 * MiB

--- a/skynet/bandwidth_test.go
+++ b/skynet/bandwidth_test.go
@@ -1,6 +1,8 @@
 package skynet
 
-import "testing"
+import (
+	"testing"
+)
 
 const (
 	// baseSectorTotalSize is the total amount of storage used by a base sector,
@@ -42,8 +44,11 @@ func TestRawStorageUsed(t *testing.T) {
 		{size: 0, result: baseSectorTotalSize},
 		{size: 1 * MiB, result: baseSectorTotalSize},
 		{size: 4 * MiB, result: baseSectorTotalSize},
+		// 4MB base sector + 1MB overflow which fits in a single 40MB chunk.
 		{size: 5 * MiB, result: baseSectorTotalSize + chunkTotalSize},
+		// 4MB base sector + 46MB overflow which fit in two 40MB chunks.
 		{size: 50 * MiB, result: baseSectorTotalSize + 2*chunkTotalSize},
+		// 4MB base sector + 496MB overflow which fit in math.Ceil(496 / 40.0) = 13 chunks.
 		{size: 500 * MiB, result: baseSectorTotalSize + 13*chunkTotalSize},
 	}
 	for _, tt := range tests {
@@ -66,6 +71,7 @@ func TestStorageUsed(t *testing.T) {
 		{size: 4 * MiB, result: baseSectorTotalSize / RedundancyAPIDivisor},
 		{size: 5 * MiB, result: (baseSectorTotalSize + chunkTotalSize) / RedundancyAPIDivisor},
 		{size: 50 * MiB, result: (baseSectorTotalSize + 2*chunkTotalSize) / RedundancyAPIDivisor},
+		// 4MB base sector + 496MB overflow which fit in math.Ceil(496 / 40.0) = 13 chunks.
 		{size: 500 * MiB, result: (baseSectorTotalSize + 13*chunkTotalSize) / RedundancyAPIDivisor},
 	}
 	for _, tt := range tests {
@@ -83,12 +89,13 @@ func TestBandwidthUploadCost(t *testing.T) {
 		size   int64
 		result int64
 	}{
-		{size: 0, result: 10 * SizeBaseSector},
-		{size: 1 * MiB, result: 10 * SizeBaseSector},
-		{size: 4 * MiB, result: 10 * SizeBaseSector},
-		{size: 5 * MiB, result: 10*SizeBaseSector + 3*SizeChunk},
-		{size: 50 * MiB, result: 10*SizeBaseSector + 2*3*SizeChunk},
-		{size: 500 * MiB, result: 10*SizeBaseSector + 13*3*SizeChunk},
+		{size: 0, result: RedundancyBaseSector * SizeBaseSector},
+		{size: 1 * MiB, result: RedundancyBaseSector * SizeBaseSector},
+		{size: 4 * MiB, result: RedundancyBaseSector * SizeBaseSector},
+		{size: 5 * MiB, result: RedundancyBaseSector*SizeBaseSector + RedundancyChunk*SizeChunk},
+		{size: 50 * MiB, result: RedundancyBaseSector*SizeBaseSector + 2*RedundancyChunk*SizeChunk},
+		// 4MB base sector + 496MB overflow which fit in math.Ceil(496 / 40.0) = 13 chunks.
+		{size: 500 * MiB, result: RedundancyBaseSector*SizeBaseSector + 13*RedundancyChunk*SizeChunk},
 	}
 	for _, tt := range tests {
 		res := BandwidthUploadCost(tt.size)

--- a/skynet/bandwidth_test.go
+++ b/skynet/bandwidth_test.go
@@ -60,29 +60,6 @@ func TestRawStorageUsed(t *testing.T) {
 	}
 }
 
-// TestStorageUsed ensures that StorageUsed works as expected.
-func TestStorageUsed(t *testing.T) {
-	tests := []struct {
-		size   int64
-		result int64
-	}{
-		{size: 0, result: baseSectorTotalSize / RedundancyAPIDivisor},
-		{size: 1 * MiB, result: baseSectorTotalSize / RedundancyAPIDivisor},
-		{size: 4 * MiB, result: baseSectorTotalSize / RedundancyAPIDivisor},
-		{size: 5 * MiB, result: (baseSectorTotalSize + chunkTotalSize) / RedundancyAPIDivisor},
-		{size: 50 * MiB, result: (baseSectorTotalSize + 2*chunkTotalSize) / RedundancyAPIDivisor},
-		// 4MB base sector + 496MB overflow which fit in math.Ceil(496 / 40.0) = 13 chunks.
-		{size: 500 * MiB, result: (baseSectorTotalSize + 13*chunkTotalSize) / RedundancyAPIDivisor},
-	}
-	for _, tt := range tests {
-		res := StorageUsed(tt.size)
-		if res != tt.result {
-			t.Errorf("Expected a %d MiB file to result into %d MiB used for upload storage, got %d MiB.",
-				tt.size/MiB, tt.result/MiB, res/MiB)
-		}
-	}
-}
-
 // TestBandwidthUploadCost ensures BandwidthUploadCost works as expected.
 func TestBandwidthUploadCost(t *testing.T) {
 	tests := []struct {

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -76,7 +76,7 @@ func TestUserStats(t *testing.T) {
 	expectedDownloadBandwidth := int64(0)
 
 	// Create a small upload.
-	skylinkSmall, err := createTestUpload(ctx, db, u, testUploadSizeSmall)
+	skylinkSmall, _, err := createTestUpload(ctx, db, u, testUploadSizeSmall)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -96,7 +96,7 @@ func TestUserStats(t *testing.T) {
 	}
 
 	// Create a big upload.
-	skylinkBig, err := createTestUpload(ctx, db, u, testUploadSizeBig)
+	skylinkBig, _, err := createTestUpload(ctx, db, u, testUploadSizeBig)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -161,7 +161,7 @@ func TestUserStats(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to register a registry read.", err)
 	}
-	expectedRegReadBandwidth := int64(skynet.PriceBandwidthRegistryRead)
+	expectedRegReadBandwidth := int64(skynet.CostBandwidthRegistryRead)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -180,7 +180,7 @@ func TestUserStats(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to register a registry read.", err)
 	}
-	expectedRegReadBandwidth += int64(skynet.PriceBandwidthRegistryRead)
+	expectedRegReadBandwidth += int64(skynet.CostBandwidthRegistryRead)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -200,7 +200,7 @@ func TestUserStats(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to register a registry write.", err)
 	}
-	expectedRegWriteBandwidth := int64(skynet.PriceBandwidthRegistryWrite)
+	expectedRegWriteBandwidth := int64(skynet.CostBandwidthRegistryWrite)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {
@@ -219,7 +219,7 @@ func TestUserStats(t *testing.T) {
 	if err != nil {
 		t.Fatal("Failed to register a registry write.", err)
 	}
-	expectedRegWriteBandwidth += int64(skynet.PriceBandwidthRegistryWrite)
+	expectedRegWriteBandwidth += int64(skynet.CostBandwidthRegistryWrite)
 	// Check bandwidth.
 	stats, err = db.UserStats(ctx, *u)
 	if err != nil {


### PR DESCRIPTION
## Overview

This PR introduces three new endpoint:
* `GET /user/limits` returns the speed limits for the user based on their account tier. It takes care to downgrade the speed of the user if they exceed their quotas.
* `DELETE /skylink/:skylink` marks the given skylink as unpinned by the current user (all uploads)
* `DELETE /user/upload/:uploadId` marks the given upload as unpinned

~~It also changes the way we calculate storage and bandwidth used by the user to be closer to the real world usage. See https://discord.com/channels/542938080349519882/542939275587485696/821722719069405184 and the subsequent discussion.~~  
Uploaded files now count towards the uploader's quota with their normal size (as seen when the file is on disk) and not based on on the raw size on the Sia network.

## Details

### User Limits

Each account tier comes with preset limits that imposes on the user's speed for uploads, downloads, and access to the registry. Users have usage quotas set on the files they upload - total upload size and total number of uploads. Once they exceed any of those, their speed limitations get dropped to those of an anonymous user.

The `GET /user/limit` endpoint fetches the user's tier from the DB, checks if the user exceeds their quotas and returns the respective values, based on a hardcoded map. If we decide to keep this long-term we'll move to a config file. Hardcoding the map seemed like a decent way to save time.

### Unpinning skylinks

The way the `DELETE /skylink/:skylink` endpoint works is by scanning the list of uploads by this user and marking all uploads of this skylink made by this user as "unpinned". `siad` is not notified of this and no other action is taken, so the files are not immediately delete. The same is true about the `DELETE /user/upload/:uploadId` but limited to single upload. The second endpoint was requested by Karol in order to make sure a specific upload in the list is being unpinned, as that makes a lot more sense for the purposes of the UI.

The intended way for this to work is that in the future the portal will scan the list of uploads for each skylink and will only refresh the contracts for those skylinks that are still being pinned by an active subscriber. All unpinned skylinks will be treated as if uploaded by an anonymous user. Once a skylink is unpinned, it no longer counts towards the user's storage quota.

### Storage and bandwidth

* ~~DB will store both the user-facing file size and the actually used storage (base sector * 10 + chunks * 3)~~
* ~~API will report on the actual used storage / 3, so it's more in line with the file sizes users see on their filesystem. We can adjust pricing based on that.~~
* ~~Add an `.env` param that adjusts that modifier.~~
* Multiple uploads of the same content (binary identical uploads) count towards the user's storage quota only once but do count towards the total number of uploads quota multiple times.

## Additional Follow-ups:

* https://github.com/NebulousLabs/skynet-accounts/pull/36#discussion_r595985187

Closes #32 
