### PR TITLE
Add a simple health check.

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -17,6 +17,18 @@ import (
 	"gitlab.com/NebulousLabs/errors"
 )
 
+// healthHandler returns the status of the service
+func (api *API) healthHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	status := struct {
+		DBAlive bool `json:"dbAlive"`
+	}{}
+	_, err := api.staticDB.UserBySub(req.Context(), "", false)
+	if err == nil || errors.Contains(err, database.ErrUserNotFound) {
+		status.DBAlive = true
+	}
+	api.WriteJSON(w, status)
+}
+
 // loginHandler starts a user session by issuing a cookie
 func (api *API) loginHandler(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	tokenStr, err := tokenFromRequest(req)

--- a/api/routes.go
+++ b/api/routes.go
@@ -15,6 +15,8 @@ import (
 
 // buildHTTPRoutes registers all HTTP routes and their handlers.
 func (api *API) buildHTTPRoutes() {
+	api.staticRouter.GET("/health", api.noValidate(api.healthHandler))
+
 	api.staticRouter.POST("/login", api.noValidate(api.loginHandler))
 	api.staticRouter.POST("/logout", api.validate(api.logoutHandler))
 


### PR DESCRIPTION
* The health check always returns 200 when the service is alive.
* The body of the health check contains a JSON with the status of the database which can be `true` or `false` (if the DB is down)

I don't mind changing the way this works to return an error code when the DB is down instead of a 200 - both would make sense to me.