### PR TITLE
WIP: Change GET /user/recover into POST /user/recover/request.

### DIFF
--- a/API.md
+++ b/API.md
@@ -211,13 +211,13 @@ Requests another confirmation email sent to the account's email address.
  - 401
  - 500
 
-### GET `/user/recover`
+### POST `/user/recover/request`
 
 Requests a recovery token to be sent to given email. The email needs to be 
 confirmed for the action to be performed.
 
 * Requires a valid JWT token: `false`
-* GET params: `email`
+* POST params: `email`
 * Returns:
 - 204
 - 400

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -794,16 +794,16 @@ func (api *API) userReconfirmPOST(w http.ResponseWriter, req *http.Request, _ ht
 	api.WriteSuccess(w)
 }
 
-// userRecoverGET allows the user to request an account recovery. This creates
-// a password-reset token that allows the user to change their password without
-// logging in.
+// userRecoverRequestPOST allows the user to request an account recovery. This
+// creates a password-reset token that allows the user to change their password
+// without logging in.
 // The user doesn't need to be logged in.
-func (api *API) userRecoverGET(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+func (api *API) userRecoverRequestPOST(w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
 	if err := req.ParseForm(); err != nil {
 		api.WriteError(w, err, http.StatusBadRequest)
 		return
 	}
-	email := req.Form.Get("email")
+	email := req.PostFormValue("email")
 	if email == "" {
 		api.WriteError(w, errors.New("missing required parameter 'email'"), http.StatusBadRequest)
 		return

--- a/api/routes.go
+++ b/api/routes.go
@@ -43,7 +43,7 @@ func (api *API) buildHTTPRoutes() {
 	// Endpoints for email communication with the user.
 	api.staticRouter.GET("/user/confirm", api.WithDBSession(api.noValidate(api.userConfirmGET)))
 	api.staticRouter.POST("/user/reconfirm", api.WithDBSession(api.validate(api.userReconfirmPOST)))
-	api.staticRouter.GET("/user/recover", api.WithDBSession(api.noValidate(api.userRecoverGET)))
+	api.staticRouter.POST("/user/recover/request", api.WithDBSession(api.noValidate(api.userRecoverRequestPOST)))
 	api.staticRouter.POST("/user/recover", api.WithDBSession(api.noValidate(api.userRecoverPOST)))
 
 	api.staticRouter.POST("/stripe/webhook", api.WithDBSession(api.noValidate(api.stripeWebhookPOST)))
@@ -103,7 +103,7 @@ func tokenFromRequest(r *http.Request) (string, error) {
 	// Check the cookie for a token.
 	cookie, err := r.Cookie(CookieName)
 	if errors.Contains(err, http.ErrNoCookie) {
-		return "", errors.New("no cookie found")
+		return "", errors.New("no authorisation token found")
 	}
 	if err != nil {
 		return "", errors.AddContext(err, "cookie exists but it's not valid")

--- a/changelog/items/key-updates/recover_post.md
+++ b/changelog/items/key-updates/recover_post.md
@@ -1,0 +1,1 @@
+- Remove the `GET /user/recover` endpoint in favour of the new `POST /user/recover/request` endpoint.

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -588,7 +588,7 @@ func testUserAccountRecovery(t *testing.T, at *test.AccountsTester) {
 	// // TEST REQUESTING RECOVERY // //
 
 	// Request recovery without supplying an email.
-	_, _, err = at.Get("/user/recover", nil)
+	_, _, err = at.Post("/user/recover/request", nil, nil)
 	if err == nil || !strings.Contains(err.Error(), badRequest) {
 		t.Fatalf("Expected '%s', got '%s'", badRequest, err)
 	}
@@ -603,7 +603,7 @@ func testUserAccountRecovery(t *testing.T, at *test.AccountsTester) {
 	attemptedEmail := hex.EncodeToString(fastrand.Bytes(16)) + "@siasky.net"
 	params := url.Values{}
 	params.Add("email", attemptedEmail)
-	_, b, err := at.Get("/user/recover", params)
+	_, b, err := at.Post("/user/recover/request", nil, params)
 	if err != nil {
 		t.Fatal(err, string(b))
 	}
@@ -619,7 +619,7 @@ func testUserAccountRecovery(t *testing.T, at *test.AccountsTester) {
 	// Request recovery with a valid but unconfirmed email.
 	params = url.Values{}
 	params.Add("email", u.Email)
-	_, _, err = at.Get("/user/recover", params)
+	_, _, err = at.Post("/user/recover/request", nil, params)
 	if err == nil || !strings.Contains(err.Error(), badRequest) {
 		t.Fatalf("Expected '%s', got '%s'", badRequest, err)
 	}
@@ -634,7 +634,7 @@ func testUserAccountRecovery(t *testing.T, at *test.AccountsTester) {
 	// with the recovery token.
 	params = url.Values{}
 	params.Add("email", u.Email)
-	_, b, err = at.Get("/user/recover", params)
+	_, b, err = at.Post("/user/recover/request", nil, params)
 	if err != nil {
 		t.Fatal(err, string(b))
 	}


### PR DESCRIPTION
# PULL REQUEST

## Overview

Requesting account recovery is a creation action and according to REST it should be a POST action.

Also, improve the way we parse portal name and log level env vars.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [x] All new methods or updated methods have clear docstrings
 - [x] Testing added or updated for new methods
 - [x] Verify if any changes impact the WebPortal Health Checks
 - [x] Approriate documentation updated
 - [x] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
