### PR TITLE
Add support for base32 skylinks.

### DIFF
--- a/changelog/items/key-updates/base32.md
+++ b/changelog/items/key-updates/base32.md
@@ -1,0 +1,1 @@
+- Add support for base32 skylinks.

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -13,6 +13,12 @@ import (
 )
 
 var (
+	// extractSkylinkRE extracts a skylink from the given string. It matches
+	// both base32 and base64 skylinks.
+	//
+	// Note: It's important that we match the base32 first because base32 is a
+	// subset of base64, so the base64 regex will match part of the base32 and
+	// return partial data which will be useless.
 	extractSkylinkRE      = regexp.MustCompile("^.*([a-z0-9]{55})|([a-zA-Z0-9-_]{46}).*$")
 	validateSkylinkHashRE = regexp.MustCompile("(^[a-z0-9]{55}$)|(^[a-zA-Z0-9-_]{46}$)")
 )

--- a/database/skylink_test.go
+++ b/database/skylink_test.go
@@ -6,22 +6,84 @@ import "testing"
 // skylink hash.
 func TestExtractSkylinkHash(t *testing.T) {
 	tests := []struct {
+		name  string
 		in    string
 		out   string
 		valid bool
 	}{
+		// base64 postfix
 		{
+			name:  "base64 postfix",
 			in:    "https://siasky.net/_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng",
 			out:   "_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng",
 			valid: true,
 		},
 		{
+			name:  "base64 postfix with path",
 			in:    "https://siasky.net/_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng/some/path",
 			out:   "_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng",
 			valid: true,
 		},
 		{
+			name:  "base64 postfix bad",
 			in:    "https://siasky.net/0A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng",
+			out:   "",
+			valid: false,
+		},
+		// base64 prefix
+		{
+			name:  "base64 prefix",
+			in:    "https://_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng.siasky.net",
+			out:   "_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng",
+			valid: true,
+		},
+		{
+			name:  "base64 prefix with path",
+			in:    "https://_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng.siasky.net/some/path",
+			out:   "_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng",
+			valid: true,
+		},
+		{
+			name:  "base64 prefix bad",
+			in:    "https://0A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng.siasky.net/",
+			out:   "",
+			valid: false,
+		},
+		// base32 postfix
+		{
+			name:  "base32 postfix",
+			in:    "https://siasky.net/vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g",
+			out:   "vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g",
+			valid: true,
+		},
+		{
+			name:  "base32 postfix with path",
+			in:    "https://siasky.net/vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g/some/path",
+			out:   "vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g",
+			valid: true,
+		},
+		{
+			name:  "base32 postfix bad",
+			in:    "https://siasky.net/vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9",
+			out:   "",
+			valid: false,
+		},
+		// base32 prefix
+		{
+			name:  "base32 prefix",
+			in:    "https://vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g.siasky.net",
+			out:   "vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g",
+			valid: true,
+		},
+		{
+			name:  "base32 prefix with path",
+			in:    "https://vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g.siasky.net/some/path",
+			out:   "vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g",
+			valid: true,
+		},
+		{
+			name:  "base32 prefix bad",
+			in:    "https://vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9.siasky.net/",
 			out:   "",
 			valid: false,
 		},
@@ -30,13 +92,50 @@ func TestExtractSkylinkHash(t *testing.T) {
 	for _, tt := range tests {
 		out, err := ExtractSkylinkHash(tt.in)
 		if tt.valid && err != nil {
-			t.Fatalf("expected %s to be valid, got error %s", tt.in, err)
+			t.Fatalf("%s: expected %s to be valid, got error %s", tt.name, tt.in, err)
 		}
 		if !tt.valid && err == nil {
-			t.Fatalf("expected %s to be invalid", tt.in)
+			t.Fatalf("%s: expected %s to be invalid", tt.name, tt.in)
 		}
 		if out != tt.out {
-			t.Fatalf("expected %s to have output %s, got %s", tt.in, tt.out, out)
+			t.Fatalf("%s: expected %s to have output %s, got %s", tt.name, tt.in, tt.out, out)
+		}
+	}
+}
+
+// TestValidSkylinkHash ensures ValidSkylinkHash works properly.
+func TestValidSkylinkHash(t *testing.T) {
+	tests := []struct {
+		name  string
+		in    string
+		valid bool
+	}{
+		{
+			name:  "base64",
+			in:    "_A70A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng",
+			valid: true,
+		},
+		{
+			name:  "base64 bad",
+			in:    "0A-ibzv2Woueb2_LutFjMq5nL9bamDtoSxYeq4nYwng",
+			valid: false,
+		},
+		{
+			name:  "base32",
+			in:    "vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9ger89cb1tas9r317g",
+			valid: true,
+		},
+		{
+			name:  "base32 bad",
+			in:    "vg7f80v8jf7fr5l2sudtnsnemhccpasppfqrd9",
+			valid: false,
+		},
+	}
+
+	for _, tt := range tests {
+		valid := ValidSkylinkHash(tt.in)
+		if valid != tt.valid {
+			t.Fatalf("%s: expected %s to return %t, got %t", tt.name, tt.in, tt.valid, valid)
 		}
 	}
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Add support for base32 skylinks.

This closes #98 and allows `blocker` and `malware-scanner` to work with base32 skylinks, as well.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
