### PR TITLE
remove install command for codespell as it fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ vet:
 
 # markdown-spellcheck runs codespell on all markdown files that are not
 # vendored.
+#
+# To manually install, run pip install codespell 1>/dev/null 2>&1
 markdown-spellcheck:
-	pip install codespell 1>/dev/null 2>&1
 	git ls-files "*.md" :\!:"vendor/**" | xargs codespell --check-filenames
 
 # lint runs golangci-lint (which includes golint, a spellcheck of the codebase,


### PR DESCRIPTION
# PULL REQUEST

## Overview
Having the install command for `codespell` as the default fails the `markdown-spellcheck` command. Moved it to a comment for individuals to install.

Some users will have pip3 vs pip which I believe is the failure. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
