### PR TITLE
Add an env var that controls the TTL of our JWTs.

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/SkynetLabs/skynet-accounts/api"
@@ -26,6 +27,8 @@ var (
 	// envAccountsJWKSFile holds the name of the environment variable which
 	// holds the path to the JWKS file we need to use. Optional.
 	envAccountsJWKSFile = "ACCOUNTS_JWKS_FILE"
+	// envJWTTTL holds the name of the environment variable for JWT TTL.
+	envJWTTTL = "ACCOUNTS_JWT_TTL"
 	// envDBHost holds the name of the environment variable for DB host.
 	envDBHost = "SKYNET_DB_HOST"
 	// envDBPort holds the name of the environment variable for DB port.
@@ -126,6 +129,11 @@ func main() {
 	}
 	if jwks := os.Getenv(envAccountsJWKSFile); jwks != "" {
 		jwt.AccountsJWKSFile = jwks
+	}
+	// Parse the optional env var that controls the TTL of the JWTs we generate.
+	jwtTTL, err := strconv.ParseInt(os.Getenv(envJWTTTL), 10, 32)
+	if err == nil && jwtTTL > 0 {
+		jwt.JWTTTL = int(jwtTTL)
 	}
 	// Fetch configuration data for sending emails.
 	emailURI := os.Getenv(envEmailURI)


### PR DESCRIPTION
# PULL REQUEST

## Overview

Having the TTL of our JWTs hardcoded is not ideal - portal operators should be able to decide how much risk they want to take on their users's behalf. Also, we want to be able to change that in order to test various features we are working on.

To address the above, this PR adds a new environment variable called `ACCOUNTS_JWT_TTL` which specifies the TTL of JWTs in seconds.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
