### PR TITLE
Don't start DB sessions if we don't need them

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -116,7 +116,7 @@ func (api *API) WithDBSession(h httprouter.Handle) httprouter.Handle {
 func (api *API) WriteError(w http.ResponseWriter, err error, code int) {
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
 	w.WriteHeader(code)
-	api.staticLogger.Debugln(code, err)
+	api.staticLogger.Errorln(code, err)
 	encodingErr := json.NewEncoder(w).Encode(errorWrap{Message: err.Error()})
 	if _, isJSONErr := encodingErr.(*json.SyntaxError); isJSONErr {
 		// Marshalling should only fail in the event of a developer error.

--- a/api/routes.go
+++ b/api/routes.go
@@ -42,7 +42,7 @@ func (api *API) buildHTTPRoutes() {
 	api.staticRouter.GET("/login", api.WithDBSession(api.noAuth(api.loginGET)))
 	api.staticRouter.POST("/login", api.WithDBSession(api.noAuth(api.loginPOST)))
 	api.staticRouter.POST("/logout", api.withAuth(api.logoutPOST))
-	api.staticRouter.GET("/register", api.WithDBSession(api.noAuth(api.registerGET)))
+	api.staticRouter.GET("/register", api.noAuth(api.registerGET))
 	api.staticRouter.POST("/register", api.WithDBSession(api.noAuth(api.registerPOST)))
 
 	// Endpoints at which Nginx reports portal usage.

--- a/api/routes.go
+++ b/api/routes.go
@@ -41,32 +41,32 @@ func (api *API) buildHTTPRoutes() {
 
 	api.staticRouter.GET("/login", api.WithDBSession(api.noAuth(api.loginGET)))
 	api.staticRouter.POST("/login", api.WithDBSession(api.noAuth(api.loginPOST)))
-	api.staticRouter.POST("/logout", api.WithDBSession(api.withAuth(api.logoutPOST)))
+	api.staticRouter.POST("/logout", api.withAuth(api.logoutPOST))
 	api.staticRouter.GET("/register", api.WithDBSession(api.noAuth(api.registerGET)))
 	api.staticRouter.POST("/register", api.WithDBSession(api.noAuth(api.registerPOST)))
 
 	// Endpoints at which Nginx reports portal usage.
-	api.staticRouter.POST("/track/upload/:skylink", api.WithDBSession(api.withAuth(api.trackUploadPOST)))
-	api.staticRouter.POST("/track/download/:skylink", api.WithDBSession(api.withAuth(api.trackDownloadPOST)))
-	api.staticRouter.POST("/track/registry/read", api.WithDBSession(api.withAuth(api.trackRegistryReadPOST)))
-	api.staticRouter.POST("/track/registry/write", api.WithDBSession(api.withAuth(api.trackRegistryWritePOST)))
+	api.staticRouter.POST("/track/upload/:skylink", api.withAuth(api.trackUploadPOST))
+	api.staticRouter.POST("/track/download/:skylink", api.withAuth(api.trackDownloadPOST))
+	api.staticRouter.POST("/track/registry/read", api.withAuth(api.trackRegistryReadPOST))
+	api.staticRouter.POST("/track/registry/write", api.withAuth(api.trackRegistryWritePOST))
 
-	api.staticRouter.POST("/user", api.WithDBSession(api.noAuth(api.userPOST))) // This will be removed in the future.
-	api.staticRouter.GET("/user", api.WithDBSession(api.withAuth(api.userGET)))
+	api.staticRouter.POST("/user", api.noAuth(api.userPOST)) // This will be removed in the future.
+	api.staticRouter.GET("/user", api.withAuth(api.userGET))
 	api.staticRouter.PUT("/user", api.WithDBSession(api.withAuth(api.userPUT)))
-	api.staticRouter.DELETE("/user", api.WithDBSession(api.withAuth(api.userDELETE)))
+	api.staticRouter.DELETE("/user", api.withAuth(api.userDELETE))
 	api.staticRouter.GET("/user/limits", api.noAuth(api.userLimitsGET))
 	api.staticRouter.GET("/user/stats", api.withAuth(api.userStatsGET))
 	api.staticRouter.GET("/user/pubkey/register", api.WithDBSession(api.withAuth(api.userPubKeyRegisterGET)))
 	api.staticRouter.POST("/user/pubkey/register", api.WithDBSession(api.withAuth(api.userPubKeyRegisterPOST)))
-	api.staticRouter.GET("/user/uploads", api.WithDBSession(api.withAuth(api.userUploadsGET)))
-	api.staticRouter.DELETE("/user/uploads/:skylink", api.WithDBSession(api.withAuth(api.userUploadsDELETE)))
-	api.staticRouter.GET("/user/downloads", api.WithDBSession(api.withAuth(api.userDownloadsGET)))
+	api.staticRouter.GET("/user/uploads", api.withAuth(api.userUploadsGET))
+	api.staticRouter.DELETE("/user/uploads/:skylink", api.withAuth(api.userUploadsDELETE))
+	api.staticRouter.GET("/user/downloads", api.withAuth(api.userDownloadsGET))
 
 	// Endpoints for user API keys.
 	api.staticRouter.POST("/user/apikeys", api.WithDBSession(api.withAuth(api.userAPIKeyPOST)))
-	api.staticRouter.GET("/user/apikeys", api.WithDBSession(api.withAuth(api.userAPIKeyGET)))
-	api.staticRouter.DELETE("/user/apikeys/:id", api.WithDBSession(api.withAuth(api.userAPIKeyDELETE)))
+	api.staticRouter.GET("/user/apikeys", api.withAuth(api.userAPIKeyGET))
+	api.staticRouter.DELETE("/user/apikeys/:id", api.withAuth(api.userAPIKeyDELETE))
 
 	// Endpoints for email communication with the user.
 	api.staticRouter.GET("/user/confirm", api.WithDBSession(api.noAuth(api.userConfirmGET))) // TODO POST

--- a/api/stripe.go
+++ b/api/stripe.go
@@ -182,16 +182,17 @@ func readStripeEvent(w http.ResponseWriter, req *http.Request) (*stripe.Event, i
 // adjusts the user's record accordingly.
 func (api *API) processStripeSub(ctx context.Context, s *stripe.Subscription) error {
 	api.staticLogger.Traceln("Processing subscription:", s.ID)
-	u, err := api.staticDB.UserByStripeID(ctx, s.Customer.ID)
-	if err != nil {
-		return errors.AddContext(err, "failed to fetch user from DB based on subscription info")
-	}
 	// Get all active subscriptions for this customer. There should be only one
 	// (or none) but we'd better check.
 	it := sub.List(&stripe.SubscriptionListParams{
 		Customer: s.Customer.ID,
 		Status:   string(stripe.SubscriptionStatusActive),
 	})
+	// TODO Allow multiple stripe ids per user?
+	u, err := api.staticDB.UserByStripeID(ctx, s.Customer.ID)
+	if err != nil {
+		return errors.AddContext(err, "failed to fetch user from DB based on subscription info")
+	}
 	// Pick the latest active plan and set the user's tier based on that.
 	subs := it.SubscriptionList().Data
 	var mostRecentSub *stripe.Subscription
@@ -225,19 +226,19 @@ func (api *API) processStripeSub(ctx context.Context, s *stripe.Subscription) er
 		Prorate:    &True,
 	}
 	for _, subsc := range subs {
-		if subsc == nil || subsc.ID == "" || (mostRecentSub != nil && subsc.ID == mostRecentSub.ID) {
+		if subsc == nil || (mostRecentSub != nil && subsc.ID == mostRecentSub.ID) {
 			continue
 		}
 		subsc, err = sub.Cancel(subsc.ID, &p)
 		if err != nil {
-			api.staticLogger.Warnf("Failed to cancel sub with id '%s' for user '%s' with Stripe customer id '%s'. Error: '%s'", subsc.ID, u.ID.Hex(), s.Customer.ID, err.Error())
+			api.staticLogger.Warnf("Failed to cancel sub with id %s for user %s with Stripe customer id %s. Error: %s", subsc.ID, u.ID.Hex(), s.Customer.ID, err.Error())
 		} else {
-			api.staticLogger.Tracef("Successfully cancelled sub with id '%s' for user '%s' with Stripe customer id '%s'.", subsc.ID, u.ID.Hex(), s.Customer.ID)
+			api.staticLogger.Tracef("Successfully cancelled sub with id %s for user %s with Stripe customer id %s.", subsc.ID, u.ID.Hex(), s.Customer.ID)
 		}
 	}
 	err = api.staticDB.UserSave(ctx, u)
 	if err == nil {
-		api.staticLogger.Tracef("Subscribed user id '%s', tier %d, until %s.", u.ID, u.Tier, u.SubscribedUntil.String())
+		api.staticLogger.Tracef("Subscribed user id %s, tier %d, until %s.", u.ID, u.Tier, u.SubscribedUntil.String())
 	}
 	// Re-set the tier cache for this user, in case their tier changed.
 	api.staticUserTierCache.Set(u)

--- a/database/user.go
+++ b/database/user.go
@@ -349,6 +349,7 @@ func (db *DB) UserCreate(ctx context.Context, emailAddr, pass, sub string, tier 
 		Sub:                              sub,
 		Tier:                             tier,
 	}
+	// TODO This part can race and create multiple accounts with the same email, unless we add DB-level uniqueness restriction.
 	// Insert the user.
 	fields, err := bson.Marshal(u)
 	if err != nil {
@@ -454,6 +455,14 @@ func (db *DB) UserDelete(ctx context.Context, u *User) error {
 	_, err = db.staticRegistryWrites.DeleteMany(ctx, filter)
 	if err != nil {
 		return errors.AddContext(err, "failed to delete user registry writes")
+	}
+	_, err = db.staticAPIKeys.DeleteMany(ctx, filter)
+	if err != nil {
+		return errors.AddContext(err, "failed to delete user API keys")
+	}
+	_, err = db.staticUnconfirmedUserUpdates.DeleteMany(ctx, bson.D{{"sub", u.Sub}})
+	if err != nil {
+		return errors.AddContext(err, "failed to delete user unconfirmed updates")
 	}
 	// Delete the actual user.
 	filter = bson.D{{"_id", u.ID}}

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,6 @@ require (
 	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/klauspost/reedsolomon v1.9.15 // indirect
 	github.com/lestrrat-go/jwx v1.2.13
-	github.com/lib/pq v1.10.4
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stripe/stripe-go/v71 v71.48.0
 	github.com/tidwall/pretty v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -357,8 +357,6 @@ github.com/lestrrat-go/jwx v1.2.13 h1:GxuOPfAz4+nzL98WaKxBxEEZ9b7qmyDetMGfBm9yVv
 github.com/lestrrat-go/jwx v1.2.13/go.mod h1:3Q3Re8TaOcVTdpx4Tvz++OWmryDklihTDqrrwQiyS2A=
 github.com/lestrrat-go/option v1.0.0 h1:WqAWL8kh8VcSoD6xjSH34/1m8yxluXQbDeKNfvFeEO4=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
-github.com/lib/pq v1.10.4 h1:SO9z7FRPzA03QhHKJrH5BXA6HU1rS4V2nIVrrNC1iYk=
-github.com/lib/pq v1.10.4/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/markbates/oncer v0.0.0-20181203154359-bf2de49a0be2/go.mod h1:Ld9puTsIW75CHf65OeIOkyKbteujpZVXDpWK6YGZbxE=


### PR DESCRIPTION
# PULL REQUEST

## Overview

Recently we've had some issues with DB writes being cancelled because of overlapping changes. One way we can resolve that is to make sure that we use DB sessions only when we actually need them (read then write, write to multiple documents, etc.). This PR does that. 

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
