### PR TITLE
add dockerfile and dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM golang:1.17.7 as builder
+LABEL maintainer="SkynetLabs <devs@skynetlabs.com>"
+
+WORKDIR /root
+
+ENV CGO_ENABLED=0
+
+COPY api api
+COPY build build
+COPY database database
+COPY email email
+COPY hash hash
+COPY jwt jwt
+COPY lib lib
+COPY metafetcher metafetcher
+COPY skynet skynet
+COPY go.mod go.sum main.go Makefile ./
+
+RUN go mod download && make release
+
+FROM alpine:3.15.0
+LABEL maintainer="SkynetLabs <devs@skynetlabs.com>"
+
+COPY --from=builder /go/bin/skynet-accounts /usr/bin/skynet-accounts
+
+ENTRYPOINT ["skynet-accounts"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,16 +5,7 @@ WORKDIR /root
 
 ENV CGO_ENABLED=0
 
-COPY api api
-COPY build build
-COPY database database
-COPY email email
-COPY hash hash
-COPY jwt jwt
-COPY lib lib
-COPY metafetcher metafetcher
-COPY skynet skynet
-COPY go.mod go.sum main.go Makefile ./
+COPY . .
 
 RUN go mod download && make release
 


### PR DESCRIPTION
- include Dockerfile (to enable docker hub builds)
- include dependabot config to make sure the image dependencies are up to date
- update golang image from 1.17.3 to 1.17.7
- introduced multi stage build - build with debian and copy binary to alpine image to reduce image size
- updated maintainer email address
- removed redundant GOOS and GOARCH env vars - those are golang image defaults anyway
- added CGO_ENABLED=0 to indicate that the resulting binary has to be standalone (required to run on alpine)