### PR TITLE
Fix /user/limits reporting wrong tier

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -50,12 +50,7 @@ func (utc *userTierCache) Get(sub string) (int, bool) {
 func (utc *userTierCache) Set(u *database.User) {
 	var ce userTierCacheEntry
 	now := time.Now().UTC()
-	if u.SubscribedUntil.Before(now) {
-		ce = userTierCacheEntry{
-			Tier:      database.TierFree,
-			ExpiresAt: now.Add(userTierCacheTTL),
-		}
-	} else if u.QuotaExceeded {
+	if u.QuotaExceeded {
 		ce = userTierCacheEntry{
 			Tier:      database.TierAnonymous,
 			ExpiresAt: now.Add(userTierCacheTTL),


### PR DESCRIPTION
# PULL REQUEST

## Overview

When reporting the user's tier, we check whether their subscription has expired and, if it has, we report `free`, regardless of their tier. This causes issues with users who are promoted manually, without having a running subscription.

The solution is to not do this manual check and rely on the Stripe webhook to take care of subscription levels.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
