### PR TITLE
Fix /user/limits quotaExceeded

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -22,8 +22,9 @@ type (
 	// userTierCacheEntry allows us to cache some basic information about the
 	// user, so we don't need to hit the DB to fetch data that rarely changes.
 	userTierCacheEntry struct {
-		Tier      int
-		ExpiresAt time.Time
+		Tier          int
+		QuotaExceeded bool
+		ExpiresAt     time.Time
 	}
 )
 
@@ -34,34 +35,25 @@ func newUserTierCache() *userTierCache {
 	}
 }
 
-// Get returns the user's tier and an OK indicator which is true when the cache
-// entry exists and hasn't expired, yet.
-func (utc *userTierCache) Get(sub string) (int, bool) {
+// Get returns the user's tier, a quota exceeded flag, and an OK indicator
+// which is true when the cache entry exists and hasn't expired, yet.
+func (utc *userTierCache) Get(sub string) (int, bool, bool) {
 	utc.mu.Lock()
 	ce, exists := utc.cache[sub]
 	utc.mu.Unlock()
 	if !exists || ce.ExpiresAt.Before(time.Now().UTC()) {
-		return database.TierAnonymous, false
+		return database.TierAnonymous, false, false
 	}
-	return ce.Tier, true
+	return ce.Tier, ce.QuotaExceeded, true
 }
 
 // Set stores the user's tier in the cache.
 func (utc *userTierCache) Set(u *database.User) {
-	var ce userTierCacheEntry
-	now := time.Now().UTC()
-	if u.QuotaExceeded {
-		ce = userTierCacheEntry{
-			Tier:      database.TierAnonymous,
-			ExpiresAt: now.Add(userTierCacheTTL),
-		}
-	} else {
-		ce = userTierCacheEntry{
-			Tier:      u.Tier,
-			ExpiresAt: now.Add(userTierCacheTTL),
-		}
-	}
 	utc.mu.Lock()
-	utc.cache[u.Sub] = ce
+	utc.cache[u.Sub] = userTierCacheEntry{
+		Tier:          u.Tier,
+		QuotaExceeded: u.QuotaExceeded,
+		ExpiresAt:     time.Now().UTC().Add(userTierCacheTTL),
+	}
 	utc.mu.Unlock()
 }

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -14,19 +14,22 @@ func TestUserTierCache(t *testing.T) {
 		Sub:             t.Name(),
 		Tier:            database.TierPremium5,
 		SubscribedUntil: time.Now().UTC().Add(100 * time.Hour),
-		QuotaExceeded:   false,
+		QuotaExceeded:   true,
 	}
 	// Get the user from the empty cache.
-	tier, ok := cache.Get(u.Sub)
+	tier, _, ok := cache.Get(u.Sub)
 	if ok || tier != database.TierAnonymous {
 		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", database.TierAnonymous, false, tier, ok)
 	}
-	// Set the use in the cache.
+	// Set the user in the cache.
 	cache.Set(u)
 	// Check again.
-	tier, ok = cache.Get(u.Sub)
+	tier, qe, ok := cache.Get(u.Sub)
 	if !ok || tier != u.Tier {
 		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", u.Tier, true, tier, ok)
+	}
+	if qe != u.QuotaExceeded {
+		t.Fatal("Quota exceeded flag doesn't match.")
 	}
 	ce, exists := cache.cache[u.Sub]
 	if !exists {

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -14,7 +14,7 @@ func TestUserTierCache(t *testing.T) {
 		Sub:             t.Name(),
 		Tier:            database.TierPremium5,
 		SubscribedUntil: time.Now().UTC().Add(100 * time.Hour),
-		QuotaExceeded:   true,
+		QuotaExceeded:   false,
 	}
 	// Get the user from the empty cache.
 	tier, _, ok := cache.Get(u.Sub)
@@ -25,6 +25,15 @@ func TestUserTierCache(t *testing.T) {
 	cache.Set(u)
 	// Check again.
 	tier, qe, ok := cache.Get(u.Sub)
+	if !ok || tier != u.Tier {
+		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", u.Tier, true, tier, ok)
+	}
+	if qe != u.QuotaExceeded {
+		t.Fatal("Quota exceeded flag doesn't match.")
+	}
+	u.QuotaExceeded = true
+	cache.Set(u)
+	tier, qe, ok = cache.Get(u.Sub)
 	if !ok || tier != u.Tier {
 		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", u.Tier, true, tier, ok)
 	}

--- a/database/challenge.go
+++ b/database/challenge.go
@@ -94,7 +94,7 @@ type (
 // NewChallenge creates a new challenge with the given type and pubKey.
 func (db *DB) NewChallenge(ctx context.Context, pubKey PubKey, cType string) (*Challenge, error) {
 	if cType != ChallengeTypeLogin && cType != ChallengeTypeRegister && cType != ChallengeTypeUpdate {
-		return nil, errors.New(fmt.Sprintf("invalid challenge type '%s'", cType))
+		return nil, fmt.Errorf("invalid challenge type '%s'", cType)
 	}
 	ch := &Challenge{
 		Challenge: hex.EncodeToString(fastrand.Bytes(ChallengeSize)),

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -199,8 +199,7 @@ func TestUserTierCache(t *testing.T) {
 		t.Fatal(err)
 	}
 	at.Cookie = test.ExtractCookie(r)
-	// Get the user's limit. Since they are on a Pro account but their
-	// SubscribedUntil is set in the past, we expect to get TierFree.
+	// Get the user's limit.
 	_, b, err := at.Get("/user/limits", nil)
 	if err != nil {
 		t.Fatal(err)
@@ -210,18 +209,14 @@ func TestUserTierCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ul.TierName != database.UserLimits[database.TierFree].TierName {
-		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, ul.TierName)
+	if ul.TierName != database.UserLimits[database.TierPremium20].TierName {
+		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierPremium20].TierName, ul.TierName)
 	}
-	if ul.TierID != database.TierFree {
-		t.Fatalf("Expected tier id '%d', got '%d'", database.TierFree, ul.TierID)
+	if ul.TierID != database.TierPremium20 {
+		t.Fatalf("Expected tier id '%d', got '%d'", database.TierPremium20, ul.TierID)
 	}
-	// Now set their SubscribedUntil in the future, so their subscription tier
-	// is active.
-	u.SubscribedUntil = time.Now().UTC().Add(365 * 24 * time.Hour)
-	err = at.DB.UserSave(at.Ctx, u.User)
-	if err != nil {
-		t.Fatal(err)
+	if ul.UploadBandwidth != database.UserLimits[database.TierPremium20].UploadBandwidth {
+		t.Fatalf("Expected upload bandwidth '%d', got '%d'", database.UserLimits[database.TierPremium20].UploadBandwidth, ul.UploadBandwidth)
 	}
 	// Register a test upload that exceeds the user's allowed storage, so their
 	// QuotaExceeded flag will get raised.
@@ -248,11 +243,14 @@ func TestUserTierCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ul.TierID != database.TierAnonymous {
-		t.Fatalf("Expected tier id '%d', got '%d'", database.TierAnonymous, ul.TierID)
+	if ul.TierID != database.TierPremium20 {
+		t.Fatalf("Expected tier id '%d', got '%d'", database.TierPremium20, ul.TierID)
 	}
-	if ul.TierName != database.UserLimits[database.TierAnonymous].TierName {
-		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierAnonymous].TierName, ul.TierName)
+	if ul.TierName != database.UserLimits[database.TierPremium20].TierName {
+		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierPremium20].TierName, ul.TierName)
+	}
+	if ul.UploadBandwidth != database.UserLimits[database.TierAnonymous].UploadBandwidth {
+		t.Fatalf("Expected upload bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].UploadBandwidth, ul.UploadBandwidth)
 	}
 	// Delete the uploaded file, so the user's quota recovers.
 	// This call should invalidate the tier cache.

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -199,7 +199,7 @@ func TestUserTierCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	at.Cookie = test.ExtractCookie(r)
+	at.SetCookie(test.ExtractCookie(r))
 	// Get the user's limit.
 	ul, _, err := at.UserLimits()
 	if err != nil {

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -248,13 +248,13 @@ func TestUserTierCache(t *testing.T) {
 			return errors.AddContext(err, "failed to unmarshal")
 		}
 		if ul.TierID != database.TierPremium20 {
-			return errors.New(fmt.Sprintf("Expected tier id '%d', got '%d'", database.TierPremium20, ul.TierID))
+			return fmt.Errorf("Expected tier id '%d', got '%d'", database.TierPremium20, ul.TierID)
 		}
 		if ul.TierName != database.UserLimits[database.TierPremium20].TierName {
-			return errors.New(fmt.Sprintf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierPremium20].TierName, ul.TierName))
+			return fmt.Errorf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierPremium20].TierName, ul.TierName)
 		}
 		if ul.UploadBandwidth != database.UserLimits[database.TierAnonymous].UploadBandwidth {
-			return errors.New(fmt.Sprintf("Expected upload bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].UploadBandwidth, ul.UploadBandwidth))
+			return fmt.Errorf("Expected upload bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].UploadBandwidth, ul.UploadBandwidth)
 		}
 		return nil
 	})
@@ -278,10 +278,10 @@ func TestUserTierCache(t *testing.T) {
 			return errors.AddContext(err, "failed to unmarshal")
 		}
 		if ul.TierID != database.TierPremium20 {
-			return errors.New(fmt.Sprintf("Expected tier id '%d', got '%d'", database.TierPremium20, ul.TierID))
+			return fmt.Errorf("Expected tier id '%d', got '%d'", database.TierPremium20, ul.TierID)
 		}
 		if ul.TierName != database.UserLimits[database.TierPremium20].TierName {
-			return errors.New(fmt.Sprintf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierPremium20].TierName, ul.TierName))
+			return fmt.Errorf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierPremium20].TierName, ul.TierName)
 		}
 		return nil
 	})

--- a/test/api/apikeys_test.go
+++ b/test/api/apikeys_test.go
@@ -20,7 +20,7 @@ func testAPIKeysFlow(t *testing.T, at *test.AccountsTester) {
 	if err != nil {
 		t.Fatal(err, string(body))
 	}
-	at.Cookie = test.ExtractCookie(r)
+	at.SetCookie(test.ExtractCookie(r))
 
 	aks := make([]database.APIKeyRecord, 0)
 
@@ -115,7 +115,7 @@ func testAPIKeysUsage(t *testing.T, at *test.AccountsTester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	at.Cookie = test.ExtractCookie(r)
+	at.SetCookie(test.ExtractCookie(r))
 	// Get the user and create a test upload, so the stats won't be all zeros.
 	u, err := at.DB.UserByEmail(at.Ctx, email)
 	if err != nil {
@@ -132,7 +132,7 @@ func testAPIKeysUsage(t *testing.T, at *test.AccountsTester) {
 		t.Fatal(err)
 	}
 	// Stop using the cookie, so we can test the API key.
-	at.Cookie = nil
+	at.ClearCredentials()
 	// We use a custom struct and not the APIKeyRecord one because that one does
 	// not render the key in JSON form and therefore it won't unmarshal it,
 	// either.

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -525,13 +525,13 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 			return errors.AddContext(err, "failed to unmarshal")
 		}
 		if tl.TierID != database.TierFree {
-			return errors.New(fmt.Sprintf("Expected to get the results for tier id %d, got %d", database.TierFree, tl.TierID))
+			return fmt.Errorf("Expected to get the results for tier id %d, got %d", database.TierFree, tl.TierID)
 		}
 		if tl.TierName != database.UserLimits[database.TierFree].TierName {
-			return errors.New(fmt.Sprintf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, tl.TierName))
+			return fmt.Errorf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, tl.TierName)
 		}
 		if tl.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
-			return errors.New(fmt.Sprintf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, tl.DownloadBandwidth))
+			return fmt.Errorf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, tl.DownloadBandwidth)
 		}
 		return nil
 	})

--- a/test/email/sender_test.go
+++ b/test/email/sender_test.go
@@ -2,6 +2,7 @@ package email
 
 import (
 	"context"
+	"fmt"
 	"strconv"
 	"sync"
 	"sync/atomic"
@@ -12,8 +13,10 @@ import (
 	"github.com/SkynetLabs/skynet-accounts/email"
 	"github.com/SkynetLabs/skynet-accounts/test"
 	"github.com/sirupsen/logrus"
+	"gitlab.com/NebulousLabs/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
+	"go.sia.tech/siad/build"
 )
 
 // TestSender goes through the standard Sender workflow and ensures that it
@@ -62,18 +65,23 @@ func TestSender(t *testing.T) {
 	}
 	// Start the sender and wait for a second.
 	sender.Start()
-	time.Sleep(2 * time.Second)
-	// Check that the email has been sent.
-	_, emails, err = db.FindEmails(ctx, filterTo, &options.FindOptions{})
+	err = build.Retry(10, 200*time.Millisecond, func() error {
+		// Check that the email has been sent.
+		_, emails, err = db.FindEmails(ctx, filterTo, &options.FindOptions{})
+		if err != nil {
+			return err
+		}
+		if len(emails) != 1 {
+			return errors.New(fmt.Sprintf("Expected 1 email in the DB, got %d\n", len(emails)))
+		}
+		if emails[0].SentAt.IsZero() {
+			emails[0].Body = "<<<Body removed for logging brevity.>>>"
+			return errors.New(fmt.Sprintf("Email not sent. Email: %+v\n", emails[0]))
+		}
+		return nil
+	})
 	if err != nil {
 		t.Fatal(err)
-	}
-	if len(emails) != 1 {
-		t.Fatalf("Expected 1 email in the DB, got %d\n", len(emails))
-	}
-	if emails[0].SentAt.IsZero() {
-		emails[0].Body = "<<<Body removed for logging brevity.>>>"
-		t.Fatalf("Email not sent. Email: %+v\n", emails[0])
 	}
 }
 

--- a/test/email/sender_test.go
+++ b/test/email/sender_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/SkynetLabs/skynet-accounts/email"
 	"github.com/SkynetLabs/skynet-accounts/test"
 	"github.com/sirupsen/logrus"
-	"gitlab.com/NebulousLabs/errors"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/mongo/options"
 	"go.sia.tech/siad/build"
@@ -72,11 +71,11 @@ func TestSender(t *testing.T) {
 			return err
 		}
 		if len(emails) != 1 {
-			return errors.New(fmt.Sprintf("Expected 1 email in the DB, got %d\n", len(emails)))
+			return fmt.Errorf("expected 1 email in the DB, got %d", len(emails))
 		}
 		if emails[0].SentAt.IsZero() {
 			emails[0].Body = "<<<Body removed for logging brevity.>>>"
-			return errors.New(fmt.Sprintf("Email not sent. Email: %+v\n", emails[0]))
+			return fmt.Errorf("email not sent. Email: %+v", emails[0])
 		}
 		return nil
 	})

--- a/test/tester.go
+++ b/test/tester.go
@@ -257,3 +257,43 @@ func (at *AccountsTester) executeRequest(req *http.Request) (*http.Response, []b
 	}
 	return r, body, err
 }
+
+// TrackDownload performs a `POST /track/download/:skylink` request.
+func (at *AccountsTester) TrackDownload(skylink string, bytes int64) (int, error) {
+	form := url.Values{}
+	form.Set("bytes", fmt.Sprint(bytes))
+	r, _, err := at.request(http.MethodPost, "/track/download/"+skylink, form, nil)
+	return r.StatusCode, err
+}
+
+// TrackUpload performs a `POST /track/upload/:skylink` request.
+func (at *AccountsTester) TrackUpload(skylink string) (int, error) {
+	r, _, err := at.request(http.MethodPost, "/track/upload/"+skylink, nil, nil)
+	return r.StatusCode, err
+}
+
+// TrackRegistryRead performs a `POST /track/registry/read` request.
+func (at *AccountsTester) TrackRegistryRead() (int, error) {
+	r, _, err := at.request(http.MethodPost, "/track/registry/read", nil, nil)
+	return r.StatusCode, err
+}
+
+// TrackRegistryWrite performs a `POST /track/registry/write` request.
+func (at *AccountsTester) TrackRegistryWrite() (int, error) {
+	r, _, err := at.request(http.MethodPost, "/track/registry/write", nil, nil)
+	return r.StatusCode, err
+}
+
+// UserLimits performs a `GET /user/limits` request.
+func (at *AccountsTester) UserLimits() (api.UserLimitsGET, int, error) {
+	r, b, err := at.request(http.MethodGet, "/user/limits", nil, nil)
+	if err != nil {
+		return api.UserLimitsGET{}, r.StatusCode, err
+	}
+	var resp api.UserLimitsGET
+	err = json.Unmarshal(b, &resp)
+	if err != nil {
+		return api.UserLimitsGET{}, 0, errors.AddContext(err, "failed to marshal the body JSON")
+	}
+	return resp, r.StatusCode, nil
+}

--- a/test/tester.go
+++ b/test/tester.go
@@ -124,6 +124,39 @@ func NewAccountsTester(dbName string) (*AccountsTester, error) {
 	return at, nil
 }
 
+// ClearCredentials removes any credentials stored by this tester, such as a
+// cookie, token, etc.
+func (at *AccountsTester) ClearCredentials() {
+	at.Cookie = nil
+	at.Token = ""
+}
+
+// Close performs a graceful shutdown of the AccountsTester service.
+func (at *AccountsTester) Close() error {
+	at.cancel()
+	if at.DB != nil {
+		err := at.DB.Disconnect(at.Ctx)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SetCookie ensures that all subsequent requests are going to use the given
+// cookie for authentication.
+func (at *AccountsTester) SetCookie(c *http.Cookie) {
+	at.ClearCredentials()
+	at.Cookie = c
+}
+
+// SetToken ensures that all subsequent requests are going to use the given
+// token for authentication.
+func (at *AccountsTester) SetToken(t string) {
+	at.ClearCredentials()
+	at.Token = t
+}
+
 // Get executes a GET request against the test service.
 //
 // NOTE: The Body of the returned response is already read and closed.
@@ -171,12 +204,6 @@ func (at *AccountsTester) Post(endpoint string, params url.Values, bodyParams ur
 // NOTE: The Body of the returned response is already read and closed.
 func (at *AccountsTester) Put(endpoint string, params url.Values, putParams url.Values) (r *http.Response, body []byte, err error) {
 	return at.request(http.MethodPut, endpoint, params, putParams)
-}
-
-// Close performs a graceful shutdown of the AccountsTester service.
-func (at *AccountsTester) Close() error {
-	at.cancel()
-	return nil
 }
 
 // CreateUserPost is a helper method that creates a new user.


### PR DESCRIPTION
# PULL REQUEST

## Overview

When a user exceeds their quota, /user/limits will keep returning their tier and tier name but the speed limits will match anonymous tier levels.

Note: This PR also includes the now infamous `ul.TierName != database.UserLimits[database.TierPremium20].TierName` fix that we've already seen in another PR. I might remove it from there and merge it here.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
Fixes: #145 
