### PR TITLE
/user/limits in bits or bytes

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -9,6 +9,7 @@ import (
 	"net/mail"
 	"net/url"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/SkynetLabs/skynet-accounts/build"
@@ -407,7 +408,7 @@ func (api *API) userLimitsGET(_ *database.User, w http.ResponseWriter, req *http
 	// inBytes is a flag indicating that the caller wants all bandwidth limits
 	// to be presented in bytes per second. The default behaviour is to present
 	// them in bits per second.
-	inBytes := req.FormValue("unit") == "byte"
+	inBytes := strings.EqualFold(req.FormValue("unit"), "byte")
 	// First check for an API key.
 	ak, err := apiKeyFromRequest(req)
 	respAnon := userLimitsGetFromTier(database.TierAnonymous, inBytes)

--- a/api/handlers.go
+++ b/api/handlers.go
@@ -79,11 +79,13 @@ type (
 		EmailConfirmed bool `json:"emailConfirmed"`
 	}
 	// UserLimitsGET is response of GET /user/limits
+	// The returned speeds might be in bits or bytes per second, depending on
+	// the client's request.
 	UserLimitsGET struct {
 		TierID            int    `json:"tierID"`
 		TierName          string `json:"tierName"`
-		UploadBandwidth   int    `json:"upload"`        // bytes per second
-		DownloadBandwidth int    `json:"download"`      // bytes per second
+		UploadBandwidth   int    `json:"upload"`        // bits or bytes per second
+		DownloadBandwidth int    `json:"download"`      // bits or bytes per second
 		MaxUploadSize     int64  `json:"maxUploadSize"` // the max size of a single upload in bytes
 		MaxNumberUploads  int    `json:"-"`
 		RegistryDelay     int    `json:"registry"` // ms delay
@@ -402,9 +404,13 @@ func (api *API) userGET(u *database.User, w http.ResponseWriter, _ *http.Request
 // NOTE: This handler needs to use the noAuth middleware in order to be able to
 // optimise its calls to the DB and the use of caching.
 func (api *API) userLimitsGET(_ *database.User, w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
+	// inBytes is a flag indicating that the caller wants all bandwidth limits
+	// to be presented in bytes per second. The default behaviour is to present
+	// them in bits per second.
+	inBytes := req.FormValue("unit") == "byte"
 	// First check for an API key.
 	ak, err := apiKeyFromRequest(req)
-	respAnon := userLimitsGetFromTier(database.TierAnonymous)
+	respAnon := userLimitsGetFromTier(database.TierAnonymous, inBytes)
 	if err == nil {
 		u, err := api.staticDB.UserByAPIKey(req.Context(), ak)
 		if err != nil {
@@ -412,12 +418,12 @@ func (api *API) userLimitsGET(_ *database.User, w http.ResponseWriter, req *http
 			api.WriteJSON(w, respAnon)
 			return
 		}
-		resp := userLimitsGetFromTier(u.Tier)
+		resp := userLimitsGetFromTier(u.Tier, inBytes)
 		// If the quota is exceeded we should keep the user's tier but report
 		// anonymous-level speeds.
 		if u.QuotaExceeded {
 			// Report the speeds for tier anonymous.
-			resp = userLimitsGetFromTier(database.TierAnonymous)
+			resp = userLimitsGetFromTier(database.TierAnonymous, inBytes)
 			// But keep reporting the user's actual tier and it's name.
 			resp.TierID = u.Tier
 			resp.TierName = database.UserLimits[u.Tier].TierName
@@ -455,12 +461,12 @@ func (api *API) userLimitsGET(_ *database.User, w http.ResponseWriter, req *http
 			build.Critical("Failed to fetch user from UserTierCache right after setting it.")
 		}
 	}
-	resp := userLimitsGetFromTier(tier)
+	resp := userLimitsGetFromTier(tier, inBytes)
 	// If the quota is exceeded we should keep the user's tier but report
 	// anonymous-level speeds.
 	if qe {
 		// Report anonymous speeds.
-		resp = userLimitsGetFromTier(database.TierAnonymous)
+		resp = userLimitsGetFromTier(database.TierAnonymous, inBytes)
 		// Keep reporting the user's actual tier and tier name.
 		resp.TierID = tier
 		resp.TierName = database.UserLimits[tier].TierName
@@ -1196,17 +1202,24 @@ func parseRequestBodyJSON(body io.ReadCloser, maxBodySize int64, objRef interfac
 }
 
 // userLimitsGetFromTier is a helper that lets us succinctly translate
-// from the database DTO to the API DTO.
-func userLimitsGetFromTier(tier int) *UserLimitsGET {
+// from the database DTO to the API DTO. The `inBytes` parameter determines
+// whether the returned speeds will be in Bps or bps.
+func userLimitsGetFromTier(tier int, inBytes bool) *UserLimitsGET {
 	t := database.UserLimits[tier]
-	return &UserLimitsGET{
-		TierID:            tier,
-		TierName:          t.TierName,
-		UploadBandwidth:   t.UploadBandwidth,
-		DownloadBandwidth: t.DownloadBandwidth,
-		MaxUploadSize:     t.MaxUploadSize,
-		MaxNumberUploads:  t.MaxNumberUploads,
-		RegistryDelay:     t.RegistryDelay,
-		Storage:           t.Storage,
+	ul := UserLimitsGET{
+		TierID:           tier,
+		TierName:         t.TierName,
+		MaxUploadSize:    t.MaxUploadSize,
+		MaxNumberUploads: t.MaxNumberUploads,
+		RegistryDelay:    t.RegistryDelay,
+		Storage:          t.Storage,
 	}
+	if inBytes {
+		ul.UploadBandwidth = t.UploadBandwidth
+		ul.DownloadBandwidth = t.DownloadBandwidth
+	} else {
+		ul.UploadBandwidth = t.UploadBandwidth * 8
+		ul.DownloadBandwidth = t.DownloadBandwidth * 8
+	}
+	return &ul
 }

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -201,7 +201,7 @@ func TestUserTierCache(t *testing.T) {
 	}
 	at.SetCookie(test.ExtractCookie(r))
 	// Get the user's limit.
-	ul, _, err := at.UserLimits()
+	ul, _, err := at.UserLimits("byte")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -236,7 +236,7 @@ func TestUserTierCache(t *testing.T) {
 	err = build.Retry(10, 200*time.Millisecond, func() error {
 		// We expect to get tier with name and id matching TierPremium20 but with
 		// speeds matching TierAnonymous.
-		ul, _, err = at.UserLimits()
+		ul, _, err = at.UserLimits("byte")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -262,7 +262,7 @@ func TestUserTierCache(t *testing.T) {
 	}
 	err = build.Retry(10, 200*time.Millisecond, func() error {
 		// We expect to get TierPremium20.
-		ul, _, err = at.UserLimits()
+		ul, _, err = at.UserLimits("byte")
 		if err != nil {
 			return errors.AddContext(err, "failed to call /user/limits")
 		}

--- a/test/tester.go
+++ b/test/tester.go
@@ -57,6 +57,7 @@ func ExtractCookie(r *http.Response) *http.Cookie {
 func NewAccountsTester(dbName string) (*AccountsTester, error) {
 	ctx := context.Background()
 	logger := logrus.New()
+	logger.Out = ioutil.Discard
 
 	// Initialise the environment.
 	jwt.PortalName = testPortalAddr
@@ -312,8 +313,12 @@ func (at *AccountsTester) TrackRegistryWrite() (int, error) {
 }
 
 // UserLimits performs a `GET /user/limits` request.
-func (at *AccountsTester) UserLimits() (api.UserLimitsGET, int, error) {
-	r, b, err := at.request(http.MethodGet, "/user/limits", nil, nil)
+func (at *AccountsTester) UserLimits(unit string) (api.UserLimitsGET, int, error) {
+	queryParams := url.Values{}
+	if unit != "" {
+		queryParams.Set("unit", unit)
+	}
+	r, b, err := at.request(http.MethodGet, "/user/limits", queryParams, nil)
 	if err != nil {
 		return api.UserLimitsGET{}, r.StatusCode, err
 	}


### PR DESCRIPTION
# PULL REQUEST

## Overview

The `/limits` endpoint returns the bandwidth limits in bits per second, which is the format most people expect to see.
The `/user/limits` endpoint, though, returns the bandwidth in bytes per second because that is what Nginx expects to see.

This discrepancy is very confusing for users and it needs to be resolved. To that end this PR adds a new query parameter which would let Nginx request the limits in bytes (see https://github.com/SkynetLabs/skynet-webportal/pull/1855) while everyone else will receive the limits in bits.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
