### PR TITLE
Skylink race

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -16,7 +16,7 @@ import (
 var (
 	// APIKeyHeader holds the name of the header we use for API keys. This
 	// header name matches the established standard used by Swagger and others.
-	APIKeyHeader = "Skynet-API-Key"
+	APIKeyHeader = "Skynet-API-Key" // #nosec
 	// ErrNoAPIKey is an error returned when we expect an API key but we don't
 	// find one.
 	ErrNoAPIKey = errors.New("no api key found")

--- a/database/skylink.go
+++ b/database/skylink.go
@@ -8,7 +8,6 @@ import (
 	"gitlab.com/SkynetLabs/skyd/skymodules"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
-	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
 )
 
@@ -51,33 +50,14 @@ func (db *DB) Skylink(ctx context.Context, skylink string) (*Skylink, error) {
 	}
 	// Try to find the skylink in the database.
 	filter := bson.D{{"skylink", skylinkHash}}
-	sr := db.staticSkylinks.FindOne(ctx, filter)
-	err = sr.Decode(&skylinkRec)
-	if errors.Contains(err, mongo.ErrNoDocuments) {
-		// It's not there, upsert it. We use upsert instead of insert in order
-		// to avoid races. And we use an update object instead of just passing
-		// the skylink record to UpdateOne because we want to omit the _id in
-		// case it has a zero value. The struct tags instruct the compiler to
-		// omit it when it's empty but that doesn't cover the case where it's
-		// zero because in that case it's a valid array of ints which happen to
-		// be zeros.
-		upsert := bson.M{"$set": bson.M{"skylink": skylinkHash}}
-		opts := options.Update().SetUpsert(true)
-		var ur *mongo.UpdateResult
-		ur, err = db.staticSkylinks.UpdateOne(ctx, filter, upsert, opts)
-		if err != nil {
-			return nil, err
-		}
-		// The UpsertedID might be nil in case the skylink got added to the DB
-		// by another server in between the calls. In that case we'll fetch the
-		// skylink record from the DB.
-		if ur.UpsertedID != nil {
-			skylinkRec.ID = ur.UpsertedID.(primitive.ObjectID)
-		} else {
-			sr = db.staticSkylinks.FindOne(ctx, filter)
-			err = sr.Decode(&skylinkRec)
-		}
+	upsert := bson.M{"$setOnInsert": bson.M{"skylink": skylinkHash}}
+	after := options.After
+	opts := &options.FindOneAndUpdateOptions{
+		ReturnDocument: &after,
+		Upsert:         &True,
 	}
+	sr := db.staticSkylinks.FindOneAndUpdate(ctx, filter, upsert, opts)
+	err = sr.Decode(&skylinkRec)
 	if err != nil {
 		return nil, err
 	}

--- a/database/upload.go
+++ b/database/upload.go
@@ -50,7 +50,7 @@ func (db *DB) UploadCreate(ctx context.Context, user User, skylink Skylink) (*Up
 		return nil, errors.New("invalid user")
 	}
 	if skylink.ID.IsZero() {
-		return nil, errors.New("invalid skylink")
+		return nil, errors.New("skylink doesn't exist")
 	}
 	up := Upload{
 		UserID:    user.ID,

--- a/main.go
+++ b/main.go
@@ -53,12 +53,12 @@ const (
 	envServerDomain = "SERVER_DOMAIN"
 	// envStripeAPIKey hold the name of the environment variable for Stripe's
 	// API key. It's only required when integrating with Stripe.
-	envStripeAPIKey = "STRIPE_API_KEY" //#nosec
+	envStripeAPIKey = "STRIPE_API_KEY" // #nosec
 	// envMaxNumAPIKeysPerUser hold the name of the environment variable which
 	// sets the limit for number of API keys a single user can create. If a user
 	// reaches that limit they can always delete some API keys in order to make
 	// space for new ones.
-	envMaxNumAPIKeysPerUser = "ACCOUNTS_MAX_NUM_API_KEYS_PER_USER" //#nosec
+	envMaxNumAPIKeysPerUser = "ACCOUNTS_MAX_NUM_API_KEYS_PER_USER" // #nosec
 )
 
 type (

--- a/main.go
+++ b/main.go
@@ -53,12 +53,12 @@ const (
 	envServerDomain = "SERVER_DOMAIN"
 	// envStripeAPIKey hold the name of the environment variable for Stripe's
 	// API key. It's only required when integrating with Stripe.
-	envStripeAPIKey = "STRIPE_API_KEY"
+	envStripeAPIKey = "STRIPE_API_KEY" //#nosec
 	// envMaxNumAPIKeysPerUser hold the name of the environment variable which
 	// sets the limit for number of API keys a single user can create. If a user
 	// reaches that limit they can always delete some API keys in order to make
 	// space for new ones.
-	envMaxNumAPIKeysPerUser = "ACCOUNTS_MAX_NUM_API_KEYS_PER_USER"
+	envMaxNumAPIKeysPerUser = "ACCOUNTS_MAX_NUM_API_KEYS_PER_USER" //#nosec
 )
 
 type (


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR fixes a problem caused by a race condition.

The race condition happens when we try to fetch a skylink from the database, we don't find it, so we decide to insert it. When inserting it, we use `upsert` in order to avoid overwriting the ID if it just so happens that another server creates that exact skylink in that very moment. The issue is that in that case the upsert operation does not do anything and it does not return an `UpsertID`. This leaves the skylink record returned by the function with a valid hash but an empty ID. This empty ID later on causes this skylink to be evaluated as invalid.

This PR makes two changes:
 - instead of "invalid skylink" we now return "skylink doesn't exist" to better capture the situation of an empty ID
 - ~~we specifically check whether the `UpsertID` we get is empty and if that's the case we fetch the skylink record from the database~~
 - we replace the `find and if it's not there upsert` flow with a single call to `findOneAndUpdate` that will only perform an update if if doesn't find the record in the DB (thanks to `$setOnInsert`), thus giving us an atomic way to either find or insert the record.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
