### PR TITLE
Use base 10 units instead of base 2 units

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -27,10 +27,10 @@ import (
 const (
 	// LimitBodySizeSmall defines a size limit for requests that we don't expect
 	// to contain a lot of data.
-	LimitBodySizeSmall = 4 * skynet.KiB
+	LimitBodySizeSmall = 4 * skynet.KB
 	// LimitBodySizeLarge defines a size limit for requests that we expect to
 	// contain a lot of data.
-	LimitBodySizeLarge = 4 * skynet.MiB
+	LimitBodySizeLarge = 4 * skynet.MB
 )
 
 type (

--- a/database/user.go
+++ b/database/user.go
@@ -34,10 +34,6 @@ const (
 	// TierMaxReserved is a guard value that helps us validate tier values.
 	TierMaxReserved
 
-	// mbpsToBytesPerSecond is a multiplier to get from megabits per second to
-	// bytes per second.
-	mbpsToBytesPerSecond = 1024 * 1024 / 8
-
 	// filesAllowedPerTB defines a limit of number of uploaded files we impose
 	// on users. While we define it per TB, we impose it based on their entire
 	// quota, so an Extreme user will be able to upload up to 400_000 files
@@ -55,50 +51,50 @@ var (
 	UserLimits = map[int]TierLimits{
 		TierAnonymous: {
 			TierName:        "anonymous",
-			UploadBandwidth: 5 * mbpsToBytesPerSecond,
+			UploadBandwidth: 5 * skynet.MB,
 			// TODO: temporarily lowered the download bandwidth on the anon tier
 			// from 20mbps to 5mpbs
-			DownloadBandwidth: 5 * mbpsToBytesPerSecond,
-			MaxUploadSize:     1 * skynet.GiB,
+			DownloadBandwidth: 5 * skynet.MB,
+			MaxUploadSize:     1 * skynet.GB,
 			MaxNumberUploads:  0,
 			RegistryDelay:     250,
 			Storage:           0,
 		},
 		TierFree: {
 			TierName:          "free",
-			UploadBandwidth:   10 * mbpsToBytesPerSecond,
-			DownloadBandwidth: 40 * mbpsToBytesPerSecond,
-			MaxUploadSize:     100 * skynet.GiB,
+			UploadBandwidth:   10 * skynet.MB,
+			DownloadBandwidth: 40 * skynet.MB,
+			MaxUploadSize:     100 * skynet.GB,
 			MaxNumberUploads:  0.1 * filesAllowedPerTB,
 			RegistryDelay:     125,
-			Storage:           100 * skynet.GiB,
+			Storage:           100 * skynet.GB,
 		},
 		TierPremium5: {
 			TierName:          "plus",
-			UploadBandwidth:   20 * mbpsToBytesPerSecond,
-			DownloadBandwidth: 80 * mbpsToBytesPerSecond,
-			MaxUploadSize:     1 * skynet.TiB,
+			UploadBandwidth:   20 * skynet.MB,
+			DownloadBandwidth: 80 * skynet.MB,
+			MaxUploadSize:     1 * skynet.TB,
 			MaxNumberUploads:  1 * filesAllowedPerTB,
 			RegistryDelay:     0,
-			Storage:           1 * skynet.TiB,
+			Storage:           1 * skynet.TB,
 		},
 		TierPremium20: {
 			TierName:          "pro",
-			UploadBandwidth:   40 * mbpsToBytesPerSecond,
-			DownloadBandwidth: 160 * mbpsToBytesPerSecond,
-			MaxUploadSize:     4 * skynet.TiB,
+			UploadBandwidth:   40 * skynet.MB,
+			DownloadBandwidth: 160 * skynet.MB,
+			MaxUploadSize:     4 * skynet.TB,
 			MaxNumberUploads:  4 * filesAllowedPerTB,
 			RegistryDelay:     0,
-			Storage:           4 * skynet.TiB,
+			Storage:           4 * skynet.TB,
 		},
 		TierPremium80: {
 			TierName:          "extreme",
-			UploadBandwidth:   80 * mbpsToBytesPerSecond,
-			DownloadBandwidth: 320 * mbpsToBytesPerSecond,
-			MaxUploadSize:     10 * skynet.TiB,
+			UploadBandwidth:   80 * skynet.MB,
+			DownloadBandwidth: 320 * skynet.MB,
+			MaxUploadSize:     10 * skynet.TB,
 			MaxNumberUploads:  20 * filesAllowedPerTB,
 			RegistryDelay:     0,
-			Storage:           20 * skynet.TiB,
+			Storage:           20 * skynet.TB,
 		},
 	}
 

--- a/skynet/bandwidth.go
+++ b/skynet/bandwidth.go
@@ -1,19 +1,19 @@
 package skynet
 
 const (
-	// KiB kilobyte
-	KiB = 1024
-	// MiB megabyte
-	MiB = 1024 * KiB
-	// GiB gigabyte
-	GiB = 1024 * MiB
-	// TiB terabyte
-	TiB = 1024 * GiB
+	// KB kilobyte
+	KB = 1000
+	// MB megabyte
+	MB = 1000 * KB
+	// GB gigabyte
+	GB = 1000 * MB
+	// TB terabyte
+	TB = 1000 * GB
 
 	// SizeBaseSector is the size of a base sector.
-	SizeBaseSector = 4 * MiB
+	SizeBaseSector = 4 * MB
 	// SizeChunk is the size of a chunk.
-	SizeChunk = 40 * MiB
+	SizeChunk = 40 * MB
 
 	// RedundancyBaseSector describes the base sector redundancy the portal is
 	// using. This is not freely configurable because we need database
@@ -25,27 +25,27 @@ const (
 	RedundancyChunk = 3
 
 	// CostBandwidthRegistryWrite the bandwidth cost of a single registry write
-	CostBandwidthRegistryWrite = 5 * MiB
+	CostBandwidthRegistryWrite = 5 * MB
 	// CostBandwidthRegistryRead the bandwidth cost of a single registry read
-	CostBandwidthRegistryRead = MiB
+	CostBandwidthRegistryRead = MB
 
 	// CostBandwidthUploadBase is the baseline bandwidth price for each upload.
 	// This is the cost of uploading the base sector.
-	CostBandwidthUploadBase = 40 * MiB
+	CostBandwidthUploadBase = 40 * MB
 	// CostBandwidthUploadIncrement is the bandwidth price per 40MB uploaded
 	// data, beyond the base sector (beyond the first 4MB). Rounded up.
-	CostBandwidthUploadIncrement = 120 * MiB
+	CostBandwidthUploadIncrement = 120 * MB
 	// CostBandwidthDownloadBase is the baseline bandwidth price for each Download.
-	CostBandwidthDownloadBase = 200 * KiB
+	CostBandwidthDownloadBase = 200 * KB
 	// CostBandwidthDownloadIncrement is the bandwidth price per 64B. Rounded up.
 	CostBandwidthDownloadIncrement = 64
 
 	// CostStorageUploadBase is the baseline storage price for each upload.
 	// This is the cost of uploading the base sector.
-	CostStorageUploadBase = 4 * MiB
+	CostStorageUploadBase = 4 * MB
 	// CostStorageUploadIncrement is the storage price for each 40MB beyond
 	// the base sector (beyond the first 4MB). Rounded up.
-	CostStorageUploadIncrement = 40 * MiB
+	CostStorageUploadIncrement = 40 * MB
 )
 
 // BandwidthUploadCost calculates the bandwidth cost of an upload with the given

--- a/skynet/bandwidth_test.go
+++ b/skynet/bandwidth_test.go
@@ -19,18 +19,18 @@ func TestNumChunks(t *testing.T) {
 		size   int64
 		result int64
 	}{
-		{size: 0 * MiB, result: 0},
-		{size: 1 * MiB, result: 0},
-		{size: 4 * MiB, result: 0},
-		{size: 5 * MiB, result: 1},
-		{size: 50 * MiB, result: 2},
-		{size: 500 * MiB, result: 13},
+		{size: 0 * MB, result: 0},
+		{size: 1 * MB, result: 0},
+		{size: 4 * MB, result: 0},
+		{size: 5 * MB, result: 1},
+		{size: 50 * MB, result: 2},
+		{size: 500 * MB, result: 13},
 	}
 	for _, tt := range tests {
 		res := numChunks(tt.size)
 		if res != tt.result {
-			t.Errorf("Expected a %d MiB file to result into %d chunks, got %d.",
-				tt.size/MiB, tt.result, res)
+			t.Errorf("Expected a %d MB file to result into %d chunks, got %d.",
+				tt.size/MB, tt.result, res)
 		}
 	}
 }
@@ -42,20 +42,20 @@ func TestRawStorageUsed(t *testing.T) {
 		result int64
 	}{
 		{size: 0, result: baseSectorTotalSize},
-		{size: 1 * MiB, result: baseSectorTotalSize},
-		{size: 4 * MiB, result: baseSectorTotalSize},
+		{size: 1 * MB, result: baseSectorTotalSize},
+		{size: 4 * MB, result: baseSectorTotalSize},
 		// 4MB base sector + 1MB overflow which fits in a single 40MB chunk.
-		{size: 5 * MiB, result: baseSectorTotalSize + chunkTotalSize},
+		{size: 5 * MB, result: baseSectorTotalSize + chunkTotalSize},
 		// 4MB base sector + 46MB overflow which fit in two 40MB chunks.
-		{size: 50 * MiB, result: baseSectorTotalSize + 2*chunkTotalSize},
+		{size: 50 * MB, result: baseSectorTotalSize + 2*chunkTotalSize},
 		// 4MB base sector + 496MB overflow which fit in math.Ceil(496 / 40.0) = 13 chunks.
-		{size: 500 * MiB, result: baseSectorTotalSize + 13*chunkTotalSize},
+		{size: 500 * MB, result: baseSectorTotalSize + 13*chunkTotalSize},
 	}
 	for _, tt := range tests {
 		res := RawStorageUsed(tt.size)
 		if res != tt.result {
-			t.Errorf("Expected a %d MiB file to result into %d MiB used for upload storage, got %d MiB.",
-				tt.size/MiB, tt.result/MiB, res/MiB)
+			t.Errorf("Expected a %d MB file to result into %d MB used for upload storage, got %d MB.",
+				tt.size/MB, tt.result/MB, res/MB)
 		}
 	}
 }
@@ -67,18 +67,18 @@ func TestBandwidthUploadCost(t *testing.T) {
 		result int64
 	}{
 		{size: 0, result: RedundancyBaseSector * SizeBaseSector},
-		{size: 1 * MiB, result: RedundancyBaseSector * SizeBaseSector},
-		{size: 4 * MiB, result: RedundancyBaseSector * SizeBaseSector},
-		{size: 5 * MiB, result: RedundancyBaseSector*SizeBaseSector + RedundancyChunk*SizeChunk},
-		{size: 50 * MiB, result: RedundancyBaseSector*SizeBaseSector + 2*RedundancyChunk*SizeChunk},
+		{size: 1 * MB, result: RedundancyBaseSector * SizeBaseSector},
+		{size: 4 * MB, result: RedundancyBaseSector * SizeBaseSector},
+		{size: 5 * MB, result: RedundancyBaseSector*SizeBaseSector + RedundancyChunk*SizeChunk},
+		{size: 50 * MB, result: RedundancyBaseSector*SizeBaseSector + 2*RedundancyChunk*SizeChunk},
 		// 4MB base sector + 496MB overflow which fit in math.Ceil(496 / 40.0) = 13 chunks.
-		{size: 500 * MiB, result: RedundancyBaseSector*SizeBaseSector + 13*RedundancyChunk*SizeChunk},
+		{size: 500 * MB, result: RedundancyBaseSector*SizeBaseSector + 13*RedundancyChunk*SizeChunk},
 	}
 	for _, tt := range tests {
 		res := BandwidthUploadCost(tt.size)
 		if res != tt.result {
-			t.Errorf("Expected a %d MiB file to result into %d MiB upload bandwidth, got %d MiB.",
-				tt.size/MiB, tt.result/MiB, res/MiB)
+			t.Errorf("Expected a %d MB file to result into %d MB upload bandwidth, got %d MB.",
+				tt.size/MB, tt.result/MB, res/MB)
 		}
 	}
 }
@@ -89,13 +89,13 @@ func TestBandwidthDownloadCost(t *testing.T) {
 		size   int64
 		result int64
 	}{
-		{size: 0, result: 200 * KiB},
-		{size: 1 * MiB, result: 200*KiB + 1*MiB},
-		{size: 1*MiB + 1, result: 200*KiB + 1*MiB + 64},
-		{size: 4 * MiB, result: 200*KiB + 4*MiB},
-		{size: 4*MiB + 1, result: 200*KiB + 4*MiB + 64},
-		{size: 50 * MiB, result: 200*KiB + 50*MiB},
-		{size: 500*MiB + 1, result: 200*KiB + 500*MiB + 64},
+		{size: 0, result: 200 * KB},
+		{size: 1 * MB, result: 200*KB + 1*MB},
+		{size: 1*MB + 1, result: 200*KB + 1*MB + 64},
+		{size: 4 * MB, result: 200*KB + 4*MB},
+		{size: 4*MB + 1, result: 200*KB + 4*MB + 64},
+		{size: 50 * MB, result: 200*KB + 50*MB},
+		{size: 500*MB + 1, result: 200*KB + 500*MB + 64},
 	}
 	for _, tt := range tests {
 		res := BandwidthDownloadCost(tt.size)

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -588,7 +588,7 @@ func testUserUploadsDELETE(t *testing.T, at *test.AccountsTester) {
 	defer at.ClearCredentials()
 
 	// Create an upload.
-	skylink, _, err := test.CreateTestUpload(at.Ctx, at.DB, u.User, 128%skynet.KiB)
+	skylink, _, err := test.CreateTestUpload(at.Ctx, at.DB, u.User, 128%skynet.KB)
 	// Make sure it shows up for this user.
 	_, b, err := at.Get("/user/uploads", nil)
 	if err != nil {

--- a/test/database/upload_test.go
+++ b/test/database/upload_test.go
@@ -48,12 +48,12 @@ func TestUploadsByUser(t *testing.T) {
 		t.Fatalf("Expected to have %d upload(s), got %d.", uploadsCount, n)
 	}
 	if ups[0].RawStorage != rawStorageUsed {
-		t.Fatalf("Expected the raw storage used of an upload with file size of %d (%d MiB) to be %d (%d MiB), got %d (%d MiB).",
-			testUploadSize, testUploadSize/skynet.MiB, rawStorageUsed, rawStorageUsed/skynet.MiB, ups[0].Size, ups[0].Size/skynet.MiB)
+		t.Fatalf("Expected the raw storage used of an upload with file size of %d (%d MB) to be %d (%d MB), got %d (%d MB).",
+			testUploadSize, testUploadSize/skynet.MB, rawStorageUsed, rawStorageUsed/skynet.MB, ups[0].Size, ups[0].Size/skynet.MB)
 	}
 	if ups[0].Size != totalUploadSize {
-		t.Fatalf("Expected the uploads size of an upload with file size of %d (%d MiB) to be %d (%d MiB), got %d (%d MiB).",
-			testUploadSize, testUploadSize/skynet.MiB, totalUploadSize, totalUploadSize/skynet.MiB, ups[0].Size, ups[0].Size/skynet.MiB)
+		t.Fatalf("Expected the uploads size of an upload with file size of %d (%d MB) to be %d (%d MB), got %d (%d MB).",
+			testUploadSize, testUploadSize/skynet.MB, totalUploadSize, totalUploadSize/skynet.MB, ups[0].Size, ups[0].Size/skynet.MB)
 	}
 	// Refresh the user's record and make sure we report storage used accurately.
 	stats, err := db.UserStats(ctx, *u)
@@ -61,16 +61,16 @@ func TestUploadsByUser(t *testing.T) {
 		t.Fatal("Failed to fetch user.", err)
 	}
 	if stats.RawStorageUsed != rawStorageUsed {
-		t.Fatalf("Expected raw storage used of %d (%d MiB), got %d (%d MiB).",
-			rawStorageUsed, rawStorageUsed/skynet.MiB, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MiB)
+		t.Fatalf("Expected raw storage used of %d (%d MB), got %d (%d MB).",
+			rawStorageUsed, rawStorageUsed/skynet.MB, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MB)
 	}
 	if stats.TotalUploadsSize != totalUploadSize {
-		t.Fatalf("Expected total upload size of %d (%d MiB), got %d (%d MiB).",
-			totalUploadSize, totalUploadSize/skynet.MiB, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MiB)
+		t.Fatalf("Expected total upload size of %d (%d MB), got %d (%d MB).",
+			totalUploadSize, totalUploadSize/skynet.MB, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MB)
 	}
 	if stats.BandwidthUploads != uploadBandwidth {
-		t.Fatalf("Expected upload bandwidth used of %d (%d MiB), got %d (%d MiB).",
-			uploadBandwidth, uploadBandwidth/skynet.MiB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
+		t.Fatalf("Expected upload bandwidth used of %d (%d MB), got %d (%d MB).",
+			uploadBandwidth, uploadBandwidth/skynet.MB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MB)
 	}
 	if stats.NumUploads != uploadsCount {
 		t.Fatalf("Expected to have %d upload(s), got %d.", uploadsCount, stats.NumUploads)
@@ -91,16 +91,16 @@ func TestUploadsByUser(t *testing.T) {
 		t.Fatal("Failed to fetch user.", err)
 	}
 	if stats.RawStorageUsed != rawStorageUsed {
-		t.Fatalf("Expected raw storage used of %d (%d MiB), got %d (%d MiB).",
-			rawStorageUsed, rawStorageUsed/skynet.MiB, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MiB)
+		t.Fatalf("Expected raw storage used of %d (%d MB), got %d (%d MB).",
+			rawStorageUsed, rawStorageUsed/skynet.MB, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MB)
 	}
 	if stats.TotalUploadsSize != totalUploadSize {
-		t.Fatalf("Expected total upload size of %d (%d MiB), got %d (%d MiB).",
-			totalUploadSize, totalUploadSize/skynet.MiB, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MiB)
+		t.Fatalf("Expected total upload size of %d (%d MB), got %d (%d MB).",
+			totalUploadSize, totalUploadSize/skynet.MB, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MB)
 	}
 	if stats.BandwidthUploads != uploadBandwidth {
-		t.Fatalf("Expected upload bandwidth used of %d (%d MiB), got %d (%d MiB).",
-			uploadBandwidth, uploadBandwidth/skynet.MiB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
+		t.Fatalf("Expected upload bandwidth used of %d (%d MB), got %d (%d MB).",
+			uploadBandwidth, uploadBandwidth/skynet.MB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MB)
 	}
 	if stats.NumUploads != uploadsCount {
 		t.Fatalf("Expected to have %d upload(s), got %d.", uploadsCount, stats.NumUploads)
@@ -120,16 +120,16 @@ func TestUploadsByUser(t *testing.T) {
 		t.Fatal("Failed to fetch user.", err)
 	}
 	if stats.RawStorageUsed != rawStorageUsed {
-		t.Fatalf("Expected raw storage used of %d (%d MiB), got %d (%d MiB).",
-			rawStorageUsed, rawStorageUsed/skynet.MiB, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MiB)
+		t.Fatalf("Expected raw storage used of %d (%d MB), got %d (%d MB).",
+			rawStorageUsed, rawStorageUsed/skynet.MB, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MB)
 	}
 	if stats.TotalUploadsSize != totalUploadSize {
-		t.Fatalf("Expected total upload size of %d (%d MiB), got %d (%d MiB).",
-			totalUploadSize, totalUploadSize/skynet.MiB, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MiB)
+		t.Fatalf("Expected total upload size of %d (%d MB), got %d (%d MB).",
+			totalUploadSize, totalUploadSize/skynet.MB, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MB)
 	}
 	if stats.BandwidthUploads != uploadBandwidth {
-		t.Fatalf("Expected upload bandwidth used of %d (%d MiB), got %d (%d MiB).",
-			uploadBandwidth, uploadBandwidth/skynet.MiB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
+		t.Fatalf("Expected upload bandwidth used of %d (%d MB), got %d (%d MB).",
+			uploadBandwidth, uploadBandwidth/skynet.MB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MB)
 	}
 	if stats.NumUploads != uploadsCount {
 		t.Fatalf("Expected to have %d upload(s), got %d.", uploadsCount, stats.NumUploads)
@@ -200,17 +200,17 @@ func TestUnpinUploads(t *testing.T) {
 		t.Fatal("Failed to fetch user1.", err)
 	}
 	if stats.RawStorageUsed != 0 {
-		t.Fatalf("Expected raw storage used of %d (%d MiB), got %d (%d MiB).",
-			0, 0, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MiB)
+		t.Fatalf("Expected raw storage used of %d (%d MB), got %d (%d MB).",
+			0, 0, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MB)
 	}
 	if stats.TotalUploadsSize != 0 {
-		t.Fatalf("Expected total upload size of %d (%d MiB), got %d (%d MiB).",
-			0, 0, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MiB)
+		t.Fatalf("Expected total upload size of %d (%d MB), got %d (%d MB).",
+			0, 0, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MB)
 	}
 	expectedUploadBandwidth := 2 * skynet.BandwidthUploadCost(testUploadSize)
 	if stats.BandwidthUploads != expectedUploadBandwidth {
-		t.Fatalf("Expected upload bandwidth used of %d (%d MiB), got %d (%d MiB).",
-			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MiB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
+		t.Fatalf("Expected upload bandwidth used of %d (%d MB), got %d (%d MB).",
+			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MB)
 	}
 	// Fetch the second user's uploads.
 	_, n, err = db.UploadsByUser(ctx, *u2, 0, database.DefaultPageSize)
@@ -227,16 +227,16 @@ func TestUnpinUploads(t *testing.T) {
 	}
 	expectedRawStorage := skynet.RawStorageUsed(testUploadSize)
 	if stats.RawStorageUsed != expectedRawStorage {
-		t.Fatalf("Expected raw storage used of %d (%d MiB), got %d (%d MiB).",
-			expectedRawStorage, expectedRawStorage, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MiB)
+		t.Fatalf("Expected raw storage used of %d (%d MB), got %d (%d MB).",
+			expectedRawStorage, expectedRawStorage, stats.RawStorageUsed, stats.RawStorageUsed/skynet.MB)
 	}
 	if stats.TotalUploadsSize != testUploadSize {
-		t.Fatalf("Expected total upload size of %d (%d MiB), got %d (%d MiB).",
-			testUploadSize, testUploadSize, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MiB)
+		t.Fatalf("Expected total upload size of %d (%d MB), got %d (%d MB).",
+			testUploadSize, testUploadSize, stats.TotalUploadsSize, stats.TotalUploadsSize/skynet.MB)
 	}
 	expectedUploadBandwidth = skynet.BandwidthUploadCost(testUploadSize)
 	if stats.BandwidthUploads != expectedUploadBandwidth {
-		t.Fatalf("Expected upload bandwidth used of %d (%d MiB), got %d (%d MiB).",
-			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MiB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
+		t.Fatalf("Expected upload bandwidth used of %d (%d MB), got %d (%d MB).",
+			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MB, stats.BandwidthUploads, stats.BandwidthUploads/skynet.MB)
 	}
 }

--- a/test/database/user_test.go
+++ b/test/database/user_test.go
@@ -486,8 +486,8 @@ func TestUserStats(t *testing.T) {
 		_ = db.UserDelete(ctx, user)
 	}(u)
 
-	testUploadSizeSmall := int64(1 + fastrand.Intn(4*skynet.MiB-1))
-	testUploadSizeBig := int64(4*skynet.MiB + 1 + fastrand.Intn(4*skynet.MiB))
+	testUploadSizeSmall := int64(1 + fastrand.Intn(4*skynet.MB-1))
+	testUploadSizeBig := int64(4*skynet.MB + 1 + fastrand.Intn(4*skynet.MB))
 	expectedUploadBandwidth := int64(0)
 	expectedDownloadBandwidth := int64(0)
 
@@ -506,9 +506,9 @@ func TestUserStats(t *testing.T) {
 		t.Fatalf("Expected a total of %d uploads, got %d.", 1, stats.NumUploads)
 	}
 	if stats.BandwidthUploads != expectedUploadBandwidth {
-		t.Fatalf("Expected upload bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MiB,
-			stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
+		t.Fatalf("Expected upload bandwidth of %d (%d MB), got %d (%d MB).",
+			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MB,
+			stats.BandwidthUploads, stats.BandwidthUploads/skynet.MB)
 	}
 
 	// Create a big upload.
@@ -526,13 +526,13 @@ func TestUserStats(t *testing.T) {
 		t.Fatalf("Expected a total of %d uploads, got %d.", 2, stats.NumUploads)
 	}
 	if stats.BandwidthUploads != expectedUploadBandwidth {
-		t.Fatalf("Expected upload bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MiB,
-			stats.BandwidthUploads, stats.BandwidthUploads/skynet.MiB)
+		t.Fatalf("Expected upload bandwidth of %d (%d MB), got %d (%d MB).",
+			expectedUploadBandwidth, expectedUploadBandwidth/skynet.MB,
+			stats.BandwidthUploads, stats.BandwidthUploads/skynet.MB)
 	}
 
 	// Register a small download.
-	smallDownload := int64(1 + fastrand.Intn(4*skynet.MiB))
+	smallDownload := int64(1 + fastrand.Intn(4*skynet.MB))
 	err = db.DownloadCreate(ctx, *u, *skylinkSmall, smallDownload)
 	if err != nil {
 		t.Fatal("Failed to download.", err)
@@ -547,12 +547,12 @@ func TestUserStats(t *testing.T) {
 		t.Fatalf("Expected a total of %d downloads, got %d.", 1, stats.NumDownloads)
 	}
 	if stats.BandwidthDownloads != expectedDownloadBandwidth {
-		t.Fatalf("Expected download bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedDownloadBandwidth, expectedDownloadBandwidth/skynet.MiB,
-			stats.BandwidthDownloads, stats.BandwidthDownloads/skynet.MiB)
+		t.Fatalf("Expected download bandwidth of %d (%d MB), got %d (%d MB).",
+			expectedDownloadBandwidth, expectedDownloadBandwidth/skynet.MB,
+			stats.BandwidthDownloads, stats.BandwidthDownloads/skynet.MB)
 	}
 	// Register a big download.
-	bigDownload := int64(100*skynet.MiB + fastrand.Intn(4*skynet.MiB))
+	bigDownload := int64(100*skynet.MB + fastrand.Intn(4*skynet.MB))
 	err = db.DownloadCreate(ctx, *u, *skylinkBig, bigDownload)
 	if err != nil {
 		t.Fatal("Failed to download.", err)
@@ -567,9 +567,9 @@ func TestUserStats(t *testing.T) {
 		t.Fatalf("Expected a total of %d downloads, got %d.", 2, stats.NumDownloads)
 	}
 	if stats.BandwidthDownloads != expectedDownloadBandwidth {
-		t.Fatalf("Expected download bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedDownloadBandwidth, expectedDownloadBandwidth/skynet.MiB,
-			stats.BandwidthDownloads, stats.BandwidthDownloads/skynet.MiB)
+		t.Fatalf("Expected download bandwidth of %d (%d MB), got %d (%d MB).",
+			expectedDownloadBandwidth, expectedDownloadBandwidth/skynet.MB,
+			stats.BandwidthDownloads, stats.BandwidthDownloads/skynet.MB)
 	}
 
 	// Register a registry read.
@@ -587,9 +587,9 @@ func TestUserStats(t *testing.T) {
 		t.Fatalf("Expected a total of %d registry reads, got %d.", 1, stats.NumRegReads)
 	}
 	if stats.BandwidthRegReads != expectedRegReadBandwidth {
-		t.Fatalf("Expected registry read bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedRegReadBandwidth, expectedRegReadBandwidth/skynet.MiB,
-			stats.BandwidthRegReads, stats.BandwidthRegReads/skynet.MiB)
+		t.Fatalf("Expected registry read bandwidth of %d (%d MB), got %d (%d MB).",
+			expectedRegReadBandwidth, expectedRegReadBandwidth/skynet.MB,
+			stats.BandwidthRegReads, stats.BandwidthRegReads/skynet.MB)
 	}
 	// Register a registry read.
 	_, err = db.RegistryReadCreate(ctx, *u)
@@ -606,9 +606,9 @@ func TestUserStats(t *testing.T) {
 		t.Fatalf("Expected a total of %d registry reads, got %d.", 2, stats.NumRegReads)
 	}
 	if stats.BandwidthRegReads != expectedRegReadBandwidth {
-		t.Fatalf("Expected registry read bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedRegReadBandwidth, expectedRegReadBandwidth/skynet.MiB,
-			stats.BandwidthRegReads, stats.BandwidthRegReads/skynet.MiB)
+		t.Fatalf("Expected registry read bandwidth of %d (%d MB), got %d (%d MB).",
+			expectedRegReadBandwidth, expectedRegReadBandwidth/skynet.MB,
+			stats.BandwidthRegReads, stats.BandwidthRegReads/skynet.MB)
 	}
 
 	// Register a registry write.
@@ -626,9 +626,9 @@ func TestUserStats(t *testing.T) {
 		t.Fatalf("Expected a total of %d registry writes, got %d.", 1, stats.NumRegWrites)
 	}
 	if stats.BandwidthRegWrites != expectedRegWriteBandwidth {
-		t.Fatalf("Expected registry write bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedRegWriteBandwidth, expectedRegWriteBandwidth/skynet.MiB,
-			stats.BandwidthRegWrites, stats.BandwidthRegWrites/skynet.MiB)
+		t.Fatalf("Expected registry write bandwidth of %d (%d MB), got %d (%d MB).",
+			expectedRegWriteBandwidth, expectedRegWriteBandwidth/skynet.MB,
+			stats.BandwidthRegWrites, stats.BandwidthRegWrites/skynet.MB)
 	}
 	// Register a registry write.
 	_, err = db.RegistryWriteCreate(ctx, *u)
@@ -645,8 +645,8 @@ func TestUserStats(t *testing.T) {
 		t.Fatalf("Expected a total of %d registry writes, got %d.", 2, stats.NumRegWrites)
 	}
 	if stats.BandwidthRegWrites != expectedRegWriteBandwidth {
-		t.Fatalf("Expected registry write bandwidth of %d (%d MiB), got %d (%d MiB).",
-			expectedRegWriteBandwidth, expectedRegWriteBandwidth/skynet.MiB,
-			stats.BandwidthRegWrites, stats.BandwidthRegWrites/skynet.MiB)
+		t.Fatalf("Expected registry write bandwidth of %d (%d MB), got %d (%d MB).",
+			expectedRegWriteBandwidth, expectedRegWriteBandwidth/skynet.MB,
+			stats.BandwidthRegWrites, stats.BandwidthRegWrites/skynet.MB)
 	}
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

Based on our discussion, we want to switch from using KiB, Kib, MiB, Mib to kB, kb, MB, Mb, i.e. go from 1024 to 1000.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
