### PR TITLE
API keys are only accepted by the `/track/*` and `/user/limits` endpoints

### DIFF
--- a/api/auth.go
+++ b/api/auth.go
@@ -33,11 +33,7 @@ func (api *API) userAndTokenByRequestToken(req *http.Request) (*database.User, j
 // It then returns the user who owns it and a token for that user.
 // It first checks the headers and then the query.
 // This method accesses the database.
-func (api *API) userAndTokenByAPIKey(req *http.Request) (*database.User, jwt2.Token, error) {
-	ak, err := apiKeyFromRequest(req)
-	if err != nil {
-		return nil, nil, err
-	}
+func (api *API) userAndTokenByAPIKey(req *http.Request, ak database.APIKey) (*database.User, jwt2.Token, error) {
 	akr, err := api.staticDB.APIKeyByKey(req.Context(), ak.String())
 	if err != nil {
 		return nil, nil, err
@@ -62,16 +58,11 @@ func (api *API) userAndTokenByAPIKey(req *http.Request) (*database.User, jwt2.To
 	return u, t, err
 }
 
-// apiKeyFromRequest extracts the API key from the request and returns it.
-// This function does not differentiate between APIKey and APIKey.
-// It first checks the headers and then the query.
+// apiKeyFromRequest extracts the API key from the request headers and returns
+// it.
 func apiKeyFromRequest(r *http.Request) (*database.APIKey, error) {
 	// Check the headers for an API key.
 	akStr := r.Header.Get(APIKeyHeader)
-	// If there is no API key in the headers, try the query.
-	if akStr == "" {
-		akStr = r.FormValue("apiKey")
-	}
 	if akStr == "" {
 		return nil, ErrNoAPIKey
 	}

--- a/api/auth_test.go
+++ b/api/auth_test.go
@@ -28,29 +28,15 @@ func TestAPIKeyFromRequest(t *testing.T) {
 		t.Fatalf("Expected '%s', got '%s'.", ErrNoAPIKey, err)
 	}
 
-	// API key from request form.
+	// API key from headers.
 	akStr := randomAPIKeyString()
-	req.Form.Add("apiKey", akStr)
+	req.Header.Set(APIKeyHeader, akStr)
 	ak, err := apiKeyFromRequest(req)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if ak.String() != akStr {
 		t.Fatalf("Expected '%s', got '%s'.", akStr, ak)
-	}
-
-	// API key from headers. Expect this to take precedence over request form.
-	token2 := randomAPIKeyString()
-	req.Header.Set(APIKeyHeader, token2)
-	ak, err = apiKeyFromRequest(req)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if ak.String() == akStr {
-		t.Fatal("Form token took precedence over headers token.")
-	}
-	if ak.String() != token2 {
-		t.Fatalf("Expected '%s', got '%s'.", token2, ak)
 	}
 }
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -14,6 +14,9 @@ var (
 	// APIKeyHeader holds the name of the header we use for API keys. This
 	// header name matches the established standard used by Swagger and others.
 	APIKeyHeader = "Skynet-API-Key" // #nosec
+	// ErrAPIKeyNotAllowed is an error returned when an API key was passed to an
+	// endpoint that doesn't allow API key use.
+	ErrAPIKeyNotAllowed = errors.New("this endpoint does not allow the use of API keys")
 	// ErrNoAPIKey is an error returned when we expect an API key but we don't
 	// find one.
 	ErrNoAPIKey = errors.New("no api key found")
@@ -36,40 +39,40 @@ func (api *API) buildHTTPRoutes() {
 
 	api.staticRouter.GET("/login", api.WithDBSession(api.noAuth(api.loginGET)))
 	api.staticRouter.POST("/login", api.WithDBSession(api.noAuth(api.loginPOST)))
-	api.staticRouter.POST("/logout", api.withAuth(api.logoutPOST))
+	api.staticRouter.POST("/logout", api.withAuth(api.logoutPOST, false))
 	api.staticRouter.GET("/register", api.noAuth(api.registerGET))
 	api.staticRouter.POST("/register", api.WithDBSession(api.noAuth(api.registerPOST)))
 
 	// Endpoints at which Nginx reports portal usage.
-	api.staticRouter.POST("/track/upload/:skylink", api.withAuth(api.trackUploadPOST))
-	api.staticRouter.POST("/track/download/:skylink", api.withAuth(api.trackDownloadPOST))
-	api.staticRouter.POST("/track/registry/read", api.withAuth(api.trackRegistryReadPOST))
-	api.staticRouter.POST("/track/registry/write", api.withAuth(api.trackRegistryWritePOST))
+	api.staticRouter.POST("/track/upload/:skylink", api.withAuth(api.trackUploadPOST, true))
+	api.staticRouter.POST("/track/download/:skylink", api.withAuth(api.trackDownloadPOST, true))
+	api.staticRouter.POST("/track/registry/read", api.withAuth(api.trackRegistryReadPOST, true))
+	api.staticRouter.POST("/track/registry/write", api.withAuth(api.trackRegistryWritePOST, true))
 
 	api.staticRouter.POST("/user", api.noAuth(api.userPOST)) // This will be removed in the future.
-	api.staticRouter.GET("/user", api.withAuth(api.userGET))
-	api.staticRouter.PUT("/user", api.WithDBSession(api.withAuth(api.userPUT)))
-	api.staticRouter.DELETE("/user", api.withAuth(api.userDELETE))
+	api.staticRouter.GET("/user", api.withAuth(api.userGET, false))
+	api.staticRouter.PUT("/user", api.WithDBSession(api.withAuth(api.userPUT, false)))
+	api.staticRouter.DELETE("/user", api.withAuth(api.userDELETE, false))
 	api.staticRouter.GET("/user/limits", api.noAuth(api.userLimitsGET))
 	api.staticRouter.GET("/user/limits/:skylink", api.noAuth(api.userLimitsSkylinkGET))
-	api.staticRouter.GET("/user/stats", api.withAuth(api.userStatsGET))
-	api.staticRouter.GET("/user/pubkey/register", api.WithDBSession(api.withAuth(api.userPubKeyRegisterGET)))
-	api.staticRouter.POST("/user/pubkey/register", api.WithDBSession(api.withAuth(api.userPubKeyRegisterPOST)))
-	api.staticRouter.GET("/user/uploads", api.withAuth(api.userUploadsGET))
-	api.staticRouter.DELETE("/user/uploads/:skylink", api.withAuth(api.userUploadsDELETE))
-	api.staticRouter.GET("/user/downloads", api.withAuth(api.userDownloadsGET))
+	api.staticRouter.GET("/user/stats", api.withAuth(api.userStatsGET, false))
+	api.staticRouter.GET("/user/pubkey/register", api.WithDBSession(api.withAuth(api.userPubKeyRegisterGET, false)))
+	api.staticRouter.POST("/user/pubkey/register", api.WithDBSession(api.withAuth(api.userPubKeyRegisterPOST, false)))
+	api.staticRouter.GET("/user/uploads", api.withAuth(api.userUploadsGET, false))
+	api.staticRouter.DELETE("/user/uploads/:skylink", api.withAuth(api.userUploadsDELETE, false))
+	api.staticRouter.GET("/user/downloads", api.withAuth(api.userDownloadsGET, false))
 
 	// Endpoints for user API keys.
-	api.staticRouter.POST("/user/apikeys", api.WithDBSession(api.withAuth(api.userAPIKeyPOST)))
-	api.staticRouter.GET("/user/apikeys", api.withAuth(api.userAPIKeyLIST))
-	api.staticRouter.GET("/user/apikeys/:id", api.withAuth(api.userAPIKeyGET))
-	api.staticRouter.PUT("/user/apikeys/:id", api.WithDBSession(api.withAuth(api.userAPIKeyPUT)))
-	api.staticRouter.PATCH("/user/apikeys/:id", api.WithDBSession(api.withAuth(api.userAPIKeyPATCH)))
-	api.staticRouter.DELETE("/user/apikeys/:id", api.withAuth(api.userAPIKeyDELETE))
+	api.staticRouter.POST("/user/apikeys", api.WithDBSession(api.withAuth(api.userAPIKeyPOST, false)))
+	api.staticRouter.GET("/user/apikeys", api.withAuth(api.userAPIKeyLIST, false))
+	api.staticRouter.GET("/user/apikeys/:id", api.withAuth(api.userAPIKeyGET, false))
+	api.staticRouter.PUT("/user/apikeys/:id", api.WithDBSession(api.withAuth(api.userAPIKeyPUT, false)))
+	api.staticRouter.PATCH("/user/apikeys/:id", api.WithDBSession(api.withAuth(api.userAPIKeyPATCH, false)))
+	api.staticRouter.DELETE("/user/apikeys/:id", api.withAuth(api.userAPIKeyDELETE, false))
 
 	// Endpoints for email communication with the user.
 	api.staticRouter.GET("/user/confirm", api.WithDBSession(api.noAuth(api.userConfirmGET))) // TODO POST
-	api.staticRouter.POST("/user/reconfirm", api.WithDBSession(api.withAuth(api.userReconfirmPOST)))
+	api.staticRouter.POST("/user/reconfirm", api.WithDBSession(api.withAuth(api.userReconfirmPOST, false)))
 	api.staticRouter.POST("/user/recover/request", api.WithDBSession(api.noAuth(api.userRecoverRequestPOST)))
 	api.staticRouter.POST("/user/recover", api.WithDBSession(api.noAuth(api.userRecoverPOST)))
 
@@ -89,11 +92,30 @@ func (api *API) noAuth(h HandlerWithUser) httprouter.Handle {
 }
 
 // withAuth ensures that the user making the request has logged in.
-func (api *API) withAuth(h HandlerWithUser) httprouter.Handle {
+func (api *API) withAuth(h HandlerWithUser, allowsAPIKey bool) httprouter.Handle {
 	return func(w http.ResponseWriter, req *http.Request, ps httprouter.Params) {
 		api.logRequest(req)
+
+		// Check for a token.
+		u, token, err := api.userAndTokenByRequestToken(req)
+		if err == nil {
+			// Embed the verified token in the context of the request.
+			ctx := jwt.ContextWithToken(req.Context(), token)
+			h(u, w, req.WithContext(ctx), ps)
+			return
+		}
+
 		// Check for an API key.
-		u, token, err := api.userAndTokenByAPIKey(req)
+		ak, err := apiKeyFromRequest(req)
+		if err != nil {
+			api.WriteError(w, err, http.StatusUnauthorized)
+			return
+		}
+		if !allowsAPIKey {
+			api.WriteError(w, ErrAPIKeyNotAllowed, http.StatusUnauthorized)
+			return
+		}
+		u, token, err = api.userAndTokenByAPIKey(req, *ak)
 		// If there is an unexpected error, that is a 500.
 		if err != nil && !errors.Contains(err, ErrNoAPIKey) && !errors.Contains(err, database.ErrInvalidAPIKey) && !errors.Contains(err, database.ErrUserNotFound) {
 			api.WriteError(w, err, http.StatusInternalServerError)
@@ -102,14 +124,6 @@ func (api *API) withAuth(h HandlerWithUser) httprouter.Handle {
 		if err != nil && (errors.Contains(err, database.ErrInvalidAPIKey) || errors.Contains(err, database.ErrUserNotFound)) {
 			api.WriteError(w, errors.AddContext(err, "failed to fetch user by API key"), http.StatusUnauthorized)
 			return
-		}
-		// If there is no API key check for a token.
-		if errors.Contains(err, ErrNoAPIKey) {
-			u, token, err = api.userAndTokenByRequestToken(req)
-			if err != nil {
-				api.WriteError(w, err, http.StatusUnauthorized)
-				return
-			}
 		}
 		// Embed the verified token in the context of the request.
 		ctx := jwt.ContextWithToken(req.Context(), token)
@@ -120,7 +134,7 @@ func (api *API) withAuth(h HandlerWithUser) httprouter.Handle {
 // logRequest logs information about the current request.
 func (api *API) logRequest(r *http.Request) {
 	hasAuth := strings.HasPrefix(r.Header.Get("Authorization"), "Bearer")
-	hasAPIKey := r.Header.Get(APIKeyHeader) != "" || r.FormValue("apiKey") != ""
+	hasAPIKey := r.Header.Get(APIKeyHeader) != ""
 	c, err := r.Cookie(CookieName)
 	hasCookie := err == nil && c != nil
 	api.staticLogger.Tracef("Processing request: %v %v, Auth: %v, API Key: %v, Cookie: %v, Referer: %v, Host: %v, RemoreAddr: %v",


### PR DESCRIPTION
# PULL REQUEST

## Overview

API keys are only accepted by the `/track/*` and `/user/limits` endpoints

API keys cannot be used via a GET parameter.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
