### PR TITLE
When a user exceeds their quota limit only their speed

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1353,15 +1353,15 @@ func userLimitsGetFromTier(tierID int, quotaExceeded, inBytes bool) *UserLimitsG
 		bpsMul = 1
 	}
 	return &UserLimitsGET{
-		TierID:   tierID,
-		TierName: t.TierName,
-		Storage:  t.Storage,
+		TierID:           tierID,
+		TierName:         t.TierName,
+		Storage:          t.Storage,
+		MaxUploadSize:    t.MaxUploadSize,
+		MaxNumberUploads: t.MaxNumberUploads,
 		// If the user exceeds their quota, there will be brought down to
 		// anonymous levels.
 		UploadBandwidth:   limitsTier.UploadBandwidth * bpsMul,
 		DownloadBandwidth: limitsTier.DownloadBandwidth * bpsMul,
-		MaxUploadSize:     limitsTier.MaxUploadSize,
-		MaxNumberUploads:  limitsTier.MaxNumberUploads,
 		RegistryDelay:     limitsTier.RegistryDelay,
 	}
 }


### PR DESCRIPTION
# PULL REQUEST

## Overview

When a user exceeds their quota limit only their speed, not the rest of their allowance.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
