### PR TITLE
Add the user's sub to the information returned by /user/limits

### DIFF
--- a/api/cache.go
+++ b/api/cache.go
@@ -22,6 +22,7 @@ type (
 	// userTierCacheEntry allows us to cache some basic information about the
 	// user, so we don't need to hit the DB to fetch data that rarely changes.
 	userTierCacheEntry struct {
+		Sub           string
 		Tier          int
 		QuotaExceeded bool
 		ExpiresAt     time.Time
@@ -37,20 +38,24 @@ func newUserTierCache() *userTierCache {
 
 // Get returns the user's tier, a quota exceeded flag, and an OK indicator
 // which is true when the cache entry exists and hasn't expired, yet.
-func (utc *userTierCache) Get(sub string) (int, bool, bool) {
+func (utc *userTierCache) Get(sub string) (userTierCacheEntry, bool) {
 	utc.mu.Lock()
 	ce, exists := utc.cache[sub]
 	utc.mu.Unlock()
 	if !exists || ce.ExpiresAt.Before(time.Now().UTC()) {
-		return database.TierAnonymous, false, false
+		anon := userTierCacheEntry{
+			Tier: database.TierAnonymous,
+		}
+		return anon, false
 	}
-	return ce.Tier, ce.QuotaExceeded, true
+	return ce, true
 }
 
 // Set stores the user's tier in the cache under the given key.
 func (utc *userTierCache) Set(key string, u *database.User) {
 	utc.mu.Lock()
 	utc.cache[key] = userTierCacheEntry{
+		Sub:           u.Sub,
 		Tier:          u.Tier,
 		QuotaExceeded: u.QuotaExceeded,
 		ExpiresAt:     time.Now().UTC().Add(userTierCacheTTL),

--- a/api/cache_test.go
+++ b/api/cache_test.go
@@ -17,27 +17,27 @@ func TestUserTierCache(t *testing.T) {
 		QuotaExceeded:   false,
 	}
 	// Get the user from the empty cache.
-	tier, _, ok := cache.Get(u.Sub)
-	if ok || tier != database.TierAnonymous {
-		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", database.TierAnonymous, false, tier, ok)
+	ce, ok := cache.Get(u.Sub)
+	if ok || ce.Tier != database.TierAnonymous {
+		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", database.TierAnonymous, false, ce.Tier, ok)
 	}
 	// Set the user in the cache.
 	cache.Set(u.Sub, u)
 	// Check again.
-	tier, qe, ok := cache.Get(u.Sub)
-	if !ok || tier != u.Tier {
-		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", u.Tier, true, tier, ok)
+	ce, ok = cache.Get(u.Sub)
+	if !ok || ce.Tier != u.Tier {
+		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", u.Tier, true, ce.Tier, ok)
 	}
-	if qe != u.QuotaExceeded {
+	if ce.QuotaExceeded != u.QuotaExceeded {
 		t.Fatal("Quota exceeded flag doesn't match.")
 	}
 	u.QuotaExceeded = true
 	cache.Set(u.Sub, u)
-	tier, qe, ok = cache.Get(u.Sub)
-	if !ok || tier != u.Tier {
-		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", u.Tier, true, tier, ok)
+	ce, ok = cache.Get(u.Sub)
+	if !ok || ce.Tier != u.Tier {
+		t.Fatalf("Expected to get tier %d and %t, got %d and %t.", u.Tier, true, ce.Tier, ok)
 	}
-	if qe != u.QuotaExceeded {
+	if ce.QuotaExceeded != u.QuotaExceeded {
 		t.Fatal("Quota exceeded flag doesn't match.")
 	}
 	ce, exists := cache.cache[u.Sub]
@@ -66,18 +66,18 @@ func TestUserTierCache(t *testing.T) {
 		t.Fatal("Invalid API key.")
 	}
 	// Try to get a value from the cache. Expect this to fail.
-	_, _, ok = cache.Get(string(ak))
+	_, ok = cache.Get(string(ak))
 	if ok {
 		t.Fatal("Did not expect to get a cache entry!")
 	}
 	// Update the cache with a custom key.
 	cache.Set(string(ak), u)
 	// Fetch the data for the custom key.
-	tier, _, ok = cache.Get(string(ak))
+	ce, ok = cache.Get(string(ak))
 	if !ok {
 		t.Fatal("Expected the entry to exist.")
 	}
-	if tier != u.Tier {
-		t.Fatalf("Expected tier %d, got %d", u.Tier, tier)
+	if ce.Tier != u.Tier {
+		t.Fatalf("Expected tier %d, got %d", u.Tier, ce.Tier)
 	}
 }

--- a/test/api/api_test.go
+++ b/test/api/api_test.go
@@ -175,6 +175,9 @@ func TestUserTierCache(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	if ul.Sub != u.Sub {
+		t.Fatalf("Expected user sub '%s', got '%s'", u.Sub, ul.Sub)
+	}
 	if ul.TierName != database.UserLimits[database.TierPremium20].TierName {
 		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierPremium20].TierName, ul.TierName)
 	}

--- a/test/api/apikeys_test.go
+++ b/test/api/apikeys_test.go
@@ -125,9 +125,12 @@ func testPrivateAPIKeysUsage(t *testing.T, at *test.AccountsTester) {
 	h := map[string]string{
 		api.APIKeyHeader: akWithKey.Key.String(),
 	}
-	ulg, _, err := at.UserLimits("", h)
-	if ulg.TierID != database.TierFree {
+	ul, _, err := at.UserLimits("", h)
+	if ul.TierID != database.TierFree {
 		t.Fatal("Unexpected user tier.")
+	}
+	if ul.Sub != u.Sub {
+		t.Fatalf("Expected user sub '%s', got '%s'", u.Sub, ul.Sub)
 	}
 }
 

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -423,58 +423,58 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 	}
 
 	// Call /user/limits with a cookie. Expect FreeTier response.
-	ul, _, err := at.UserLimits("byte", nil)
+	tl, _, err := at.UserLimits("byte", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ul.Sub != u.Sub {
-		t.Fatalf("Expected user sub '%s', got '%s'", u.Sub, ul.Sub)
+	if tl.Sub != u.Sub {
+		t.Fatalf("Expected user sub '%s', got '%s'", u.Sub, tl.Sub)
 	}
-	if ul.TierID != database.TierFree {
-		t.Fatalf("Expected to get the results for tier id %d, got %d", database.TierFree, ul.TierID)
+	if tl.TierID != database.TierFree {
+		t.Fatalf("Expected to get the results for tier id %d, got %d", database.TierFree, tl.TierID)
 	}
-	if ul.TierName != database.UserLimits[database.TierFree].TierName {
-		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, ul.TierName)
+	if tl.TierName != database.UserLimits[database.TierFree].TierName {
+		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, tl.TierName)
 	}
-	if ul.DownloadBandwidth != database.UserLimits[database.TierFree].DownloadBandwidth {
-		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierFree].DownloadBandwidth, ul.DownloadBandwidth)
+	if tl.DownloadBandwidth != database.UserLimits[database.TierFree].DownloadBandwidth {
+		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierFree].DownloadBandwidth, tl.DownloadBandwidth)
 	}
 
 	// Call /user/limits without a cookie. Expect FreeAnonymous response.
 	at.ClearCredentials()
-	ul, _, err = at.UserLimits("byte", nil)
+	tl, _, err = at.UserLimits("byte", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ul.Sub != "" {
-		t.Fatalf("Expected user sub '%s', got '%s'", "", ul.Sub)
+	if tl.Sub != "" {
+		t.Fatalf("Expected user sub '%s', got '%s'", "", tl.Sub)
 	}
-	if ul.TierID != database.TierAnonymous {
-		t.Fatalf("Expected to get the results for tier id %d, got %d", database.TierAnonymous, ul.TierID)
+	if tl.TierID != database.TierAnonymous {
+		t.Fatalf("Expected to get the results for tier id %d, got %d", database.TierAnonymous, tl.TierID)
 	}
-	if ul.TierName != database.UserLimits[database.TierAnonymous].TierName {
-		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierAnonymous].TierName, ul.TierName)
+	if tl.TierName != database.UserLimits[database.TierAnonymous].TierName {
+		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierAnonymous].TierName, tl.TierName)
 	}
-	if ul.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
-		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, ul.DownloadBandwidth)
+	if tl.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
+		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, tl.DownloadBandwidth)
 	}
 
 	// Call /user/limits with an API key. Expect TierFree response.
-	ul, _, err = at.UserLimits("byte", map[string]string{api.APIKeyHeader: string(akr.Key)})
+	tl, _, err = at.UserLimits("byte", map[string]string{api.APIKeyHeader: string(akr.Key)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if ul.Sub != u.Sub {
-		t.Fatalf("Expected user sub '%s', got '%s'", u.Sub, ul.Sub)
+	if tl.Sub != u.Sub {
+		t.Fatalf("Expected user sub '%s', got '%s'", u.Sub, tl.Sub)
 	}
-	if ul.TierName != database.UserLimits[database.TierFree].TierName {
-		t.Fatalf("Expected to get the results for %s, got %s", database.UserLimits[database.TierFree].TierName, ul.TierName)
+	if tl.TierName != database.UserLimits[database.TierFree].TierName {
+		t.Fatalf("Expected to get the results for %s, got %s", database.UserLimits[database.TierFree].TierName, tl.TierName)
 	}
-	if ul.TierName != database.UserLimits[database.TierFree].TierName {
-		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, ul.TierName)
+	if tl.TierName != database.UserLimits[database.TierFree].TierName {
+		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, tl.TierName)
 	}
-	if ul.DownloadBandwidth != database.UserLimits[database.TierFree].DownloadBandwidth {
-		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierFree].DownloadBandwidth, ul.DownloadBandwidth)
+	if tl.DownloadBandwidth != database.UserLimits[database.TierFree].DownloadBandwidth {
+		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierFree].DownloadBandwidth, tl.DownloadBandwidth)
 	}
 
 	// Create a new user which we'll use to test the quota limits. We can't use
@@ -512,18 +512,18 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 	err = build.Retry(10, 200*time.Millisecond, func() error {
 		// Check the user's limits. We expect the tier to be Free but the limits to
 		// match Anonymous.
-		ul, _, err = at.UserLimits("byte", nil)
+		tl, _, err = at.UserLimits("byte", nil)
 		if err != nil {
 			return errors.AddContext(err, "failed to call /user/limits")
 		}
-		if ul.TierID != database.TierFree {
-			return fmt.Errorf("Expected to get the results for tier id %d, got %d", database.TierFree, ul.TierID)
+		if tl.TierID != database.TierFree {
+			return fmt.Errorf("Expected to get the results for tier id %d, got %d", database.TierFree, tl.TierID)
 		}
-		if ul.TierName != database.UserLimits[database.TierFree].TierName {
-			return fmt.Errorf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, ul.TierName)
+		if tl.TierName != database.UserLimits[database.TierFree].TierName {
+			return fmt.Errorf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, tl.TierName)
 		}
-		if ul.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
-			return fmt.Errorf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, ul.DownloadBandwidth)
+		if tl.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
+			return fmt.Errorf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, tl.DownloadBandwidth)
 		}
 		return nil
 	})
@@ -533,7 +533,7 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 
 	// Test the `unit` parameter. The only valid value is `byte`, anything else
 	// is ignored and the results are returned in bits per second.
-	ul, _, err = at.UserLimits("", nil)
+	tl, _, err = at.UserLimits("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -542,15 +542,15 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tlBits.UploadBandwidth != ul.UploadBandwidth || tlBits.DownloadBandwidth != ul.DownloadBandwidth {
-		t.Fatalf("Expected these to be equal. %+v, %+v", ul, tlBits)
+	if tlBits.UploadBandwidth != tl.UploadBandwidth || tlBits.DownloadBandwidth != tl.DownloadBandwidth {
+		t.Fatalf("Expected these to be equal. %+v, %+v", tl, tlBits)
 	}
 	tlBytes, _, err := at.UserLimits("byte", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tlBytes.UploadBandwidth*8 != ul.UploadBandwidth || tlBytes.DownloadBandwidth*8 != ul.DownloadBandwidth {
-		t.Fatalf("Invalid values in bytes. Values in bps: %+v, values in Bps: %+v", ul, tlBytes)
+	if tlBytes.UploadBandwidth*8 != tl.UploadBandwidth || tlBytes.DownloadBandwidth*8 != tl.DownloadBandwidth {
+		t.Fatalf("Invalid values in bytes. Values in bps: %+v, values in Bps: %+v", tl, tlBytes)
 	}
 	// Ensure we're not case-sensitive.
 	tlBytes2, _, err := at.UserLimits("ByTe", nil)

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -423,49 +423,58 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 	}
 
 	// Call /user/limits with a cookie. Expect FreeTier response.
-	tl, _, err := at.UserLimits("byte", nil)
+	ul, _, err := at.UserLimits("byte", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tl.TierID != database.TierFree {
-		t.Fatalf("Expected to get the results for tier id %d, got %d", database.TierFree, tl.TierID)
+	if ul.Sub != u.Sub {
+		t.Fatalf("Expected user sub '%s', got '%s'", u.Sub, ul.Sub)
 	}
-	if tl.TierName != database.UserLimits[database.TierFree].TierName {
-		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, tl.TierName)
+	if ul.TierID != database.TierFree {
+		t.Fatalf("Expected to get the results for tier id %d, got %d", database.TierFree, ul.TierID)
 	}
-	if tl.DownloadBandwidth != database.UserLimits[database.TierFree].DownloadBandwidth {
-		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierFree].DownloadBandwidth, tl.DownloadBandwidth)
+	if ul.TierName != database.UserLimits[database.TierFree].TierName {
+		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, ul.TierName)
+	}
+	if ul.DownloadBandwidth != database.UserLimits[database.TierFree].DownloadBandwidth {
+		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierFree].DownloadBandwidth, ul.DownloadBandwidth)
 	}
 
 	// Call /user/limits without a cookie. Expect FreeAnonymous response.
 	at.ClearCredentials()
-	tl, _, err = at.UserLimits("byte", nil)
+	ul, _, err = at.UserLimits("byte", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tl.TierID != database.TierAnonymous {
-		t.Fatalf("Expected to get the results for tier id %d, got %d", database.TierAnonymous, tl.TierID)
+	if ul.Sub != "" {
+		t.Fatalf("Expected user sub '%s', got '%s'", "", ul.Sub)
 	}
-	if tl.TierName != database.UserLimits[database.TierAnonymous].TierName {
-		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierAnonymous].TierName, tl.TierName)
+	if ul.TierID != database.TierAnonymous {
+		t.Fatalf("Expected to get the results for tier id %d, got %d", database.TierAnonymous, ul.TierID)
 	}
-	if tl.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
-		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, tl.DownloadBandwidth)
+	if ul.TierName != database.UserLimits[database.TierAnonymous].TierName {
+		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierAnonymous].TierName, ul.TierName)
+	}
+	if ul.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
+		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, ul.DownloadBandwidth)
 	}
 
 	// Call /user/limits with an API key. Expect TierFree response.
-	tl, _, err = at.UserLimits("byte", map[string]string{api.APIKeyHeader: string(akr.Key)})
+	ul, _, err = at.UserLimits("byte", map[string]string{api.APIKeyHeader: string(akr.Key)})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tl.TierName != database.UserLimits[database.TierFree].TierName {
-		t.Fatalf("Expected to get the results for %s, got %s", database.UserLimits[database.TierFree].TierName, tl.TierName)
+	if ul.Sub != u.Sub {
+		t.Fatalf("Expected user sub '%s', got '%s'", u.Sub, ul.Sub)
 	}
-	if tl.TierName != database.UserLimits[database.TierFree].TierName {
-		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, tl.TierName)
+	if ul.TierName != database.UserLimits[database.TierFree].TierName {
+		t.Fatalf("Expected to get the results for %s, got %s", database.UserLimits[database.TierFree].TierName, ul.TierName)
 	}
-	if tl.DownloadBandwidth != database.UserLimits[database.TierFree].DownloadBandwidth {
-		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierFree].DownloadBandwidth, tl.DownloadBandwidth)
+	if ul.TierName != database.UserLimits[database.TierFree].TierName {
+		t.Fatalf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, ul.TierName)
+	}
+	if ul.DownloadBandwidth != database.UserLimits[database.TierFree].DownloadBandwidth {
+		t.Fatalf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierFree].DownloadBandwidth, ul.DownloadBandwidth)
 	}
 
 	// Create a new user which we'll use to test the quota limits. We can't use
@@ -503,18 +512,18 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 	err = build.Retry(10, 200*time.Millisecond, func() error {
 		// Check the user's limits. We expect the tier to be Free but the limits to
 		// match Anonymous.
-		tl, _, err = at.UserLimits("byte", nil)
+		ul, _, err = at.UserLimits("byte", nil)
 		if err != nil {
 			return errors.AddContext(err, "failed to call /user/limits")
 		}
-		if tl.TierID != database.TierFree {
-			return fmt.Errorf("Expected to get the results for tier id %d, got %d", database.TierFree, tl.TierID)
+		if ul.TierID != database.TierFree {
+			return fmt.Errorf("Expected to get the results for tier id %d, got %d", database.TierFree, ul.TierID)
 		}
-		if tl.TierName != database.UserLimits[database.TierFree].TierName {
-			return fmt.Errorf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, tl.TierName)
+		if ul.TierName != database.UserLimits[database.TierFree].TierName {
+			return fmt.Errorf("Expected tier name '%s', got '%s'", database.UserLimits[database.TierFree].TierName, ul.TierName)
 		}
-		if tl.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
-			return fmt.Errorf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, tl.DownloadBandwidth)
+		if ul.DownloadBandwidth != database.UserLimits[database.TierAnonymous].DownloadBandwidth {
+			return fmt.Errorf("Expected download bandwidth '%d', got '%d'", database.UserLimits[database.TierAnonymous].DownloadBandwidth, ul.DownloadBandwidth)
 		}
 		return nil
 	})
@@ -524,7 +533,7 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 
 	// Test the `unit` parameter. The only valid value is `byte`, anything else
 	// is ignored and the results are returned in bits per second.
-	tl, _, err = at.UserLimits("", nil)
+	ul, _, err = at.UserLimits("", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -533,15 +542,15 @@ func testUserLimits(t *testing.T, at *test.AccountsTester) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tlBits.UploadBandwidth != tl.UploadBandwidth || tlBits.DownloadBandwidth != tl.DownloadBandwidth {
-		t.Fatalf("Expected these to be equal. %+v, %+v", tl, tlBits)
+	if tlBits.UploadBandwidth != ul.UploadBandwidth || tlBits.DownloadBandwidth != ul.DownloadBandwidth {
+		t.Fatalf("Expected these to be equal. %+v, %+v", ul, tlBits)
 	}
 	tlBytes, _, err := at.UserLimits("byte", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if tlBytes.UploadBandwidth*8 != tl.UploadBandwidth || tlBytes.DownloadBandwidth*8 != tl.DownloadBandwidth {
-		t.Fatalf("Invalid values in bytes. Values in bps: %+v, values in Bps: %+v", tl, tlBytes)
+	if tlBytes.UploadBandwidth*8 != ul.UploadBandwidth || tlBytes.DownloadBandwidth*8 != ul.DownloadBandwidth {
+		t.Fatalf("Invalid values in bytes. Values in bps: %+v, values in Bps: %+v", ul, tlBytes)
 	}
 	// Ensure we're not case-sensitive.
 	tlBytes2, _, err := at.UserLimits("ByTe", nil)


### PR DESCRIPTION
# PULL REQUEST

## Overview

Add the user's sub to the information returned by /user/limits, so that can be cached and cross-referenced later in nginx's access logs.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
Closes #181 
