### PR TITLE
Allow account recovery from unconfirmed emails.

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1013,11 +1013,6 @@ func (api *API) userRecoverRequestPOST(_ *database.User, w http.ResponseWriter, 
 		api.WriteError(w, errors.AddContext(err, "failed to fetch the user with this email"), http.StatusInternalServerError)
 		return
 	}
-	// Verify that the user's email is confirmed.
-	if u.EmailConfirmationToken != "" {
-		api.WriteError(w, errors.New("user's email is not confirmed. it cannot be used for account recovery"), http.StatusBadRequest)
-		return
-	}
 	// Generate a new recovery token and add it to the user's account.
 	u.RecoveryToken, err = lib.GenerateUUID()
 	if err != nil {

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -728,18 +728,8 @@ func testUserAccountRecovery(t *testing.T, at *test.AccountsTester) {
 	if len(msgs) != 1 || msgs[0].Subject != "Account access attempted" {
 		t.Fatalf("Expected to find a single email with subject '%s', got %v", "Account access attempted", msgs)
 	}
-	// Request recovery with a valid but unconfirmed email.
-	_, err = at.UserRecoverRequestPOST(u.Email)
-	if err == nil || !strings.Contains(err.Error(), badRequest) {
-		t.Fatalf("Expected '%s', got '%s'", badRequest, err)
-	}
-	// Confirm the email.
-	_, err = at.UserConfirmGET(u.EmailConfirmationToken)
-	if err != nil {
-		t.Fatal(err)
-	}
 	// Request recovery with a valid email. We expect there to be a single email
-	// with the recovery token.
+	// with the recovery token. The email is unconfirmed but we don't mind that.
 	bodyParams := url.Values{}
 	bodyParams.Set("email", u.Email)
 	_, err = at.UserRecoverRequestPOST(u.Email)


### PR DESCRIPTION
# PULL REQUEST

## Overview

As discussed previously, requiring the user's email to be confirmed in order to recover their account is too much of a limitation and we should remove it. This PR does that.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
