### PR TITLE
Stop tracking registry accesses

### DIFF
--- a/api/handlers.go
+++ b/api/handlers.go
@@ -1200,22 +1200,14 @@ func (api *API) trackDownloadPOST(u *database.User, w http.ResponseWriter, req *
 }
 
 // trackRegistryReadPOST registers a new registry read in the system.
-func (api *API) trackRegistryReadPOST(u *database.User, w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	_, err := api.staticDB.RegistryReadCreate(req.Context(), *u)
-	if err != nil {
-		api.WriteError(w, err, http.StatusInternalServerError)
-		return
-	}
+func (api *API) trackRegistryReadPOST(_ *database.User, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	// Tracking registry reads is disabled.
 	api.WriteSuccess(w)
 }
 
 // trackRegistryWritePOST registers a new registry write in the system.
-func (api *API) trackRegistryWritePOST(u *database.User, w http.ResponseWriter, req *http.Request, _ httprouter.Params) {
-	_, err := api.staticDB.RegistryWriteCreate(req.Context(), *u)
-	if err != nil {
-		api.WriteError(w, err, http.StatusInternalServerError)
-		return
-	}
+func (api *API) trackRegistryWritePOST(_ *database.User, w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	// Tracking registry writes is disabled.
 	api.WriteSuccess(w)
 }
 

--- a/database/schema.go
+++ b/database/schema.go
@@ -42,18 +42,6 @@ var (
 				Options: options.Index().SetName("skylink_id"),
 			},
 		},
-		collRegistryReads: {
-			{
-				Keys:    bson.D{{"user_id", 1}},
-				Options: options.Index().SetName("user_id"),
-			},
-		},
-		collRegistryWrites: {
-			{
-				Keys:    bson.D{{"user_id", 1}},
-				Options: options.Index().SetName("user_id"),
-			},
-		},
 		collEmails: {
 			{
 				Keys:    bson.D{{"failed_attempts", 1}},

--- a/test/api/handlers_test.go
+++ b/test/api/handlers_test.go
@@ -909,38 +909,6 @@ func testTrackingAndStats(t *testing.T, at *test.AccountsTester) {
 	expectedStats.BandwidthDownloads += skynet.BandwidthDownloadCost(200)
 	expectedStats.TotalDownloadsSize += 200
 
-	// Call trackRegistryRead without a cookie.
-	at.ClearCredentials()
-	_, err = at.TrackRegistryRead()
-	if err == nil || !strings.Contains(err.Error(), unauthorized) {
-		t.Fatalf("Expected error '%s', got '%v'", unauthorized, err)
-	}
-	at.SetCookie(c)
-	// Call trackRegistryRead.
-	_, err = at.TrackRegistryRead()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Adjust the expectations.
-	expectedStats.NumRegReads++
-	expectedStats.BandwidthRegReads += skynet.CostBandwidthRegistryRead
-
-	// Call trackRegistryWrite without a cookie.
-	at.ClearCredentials()
-	_, err = at.TrackRegistryWrite()
-	if err == nil || !strings.Contains(err.Error(), unauthorized) {
-		t.Fatalf("Expected error '%s', got '%v'", unauthorized, err)
-	}
-	at.SetCookie(c)
-	// Call trackRegistryWrite.
-	_, err = at.TrackRegistryWrite()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// Adjust the expectations.
-	expectedStats.NumRegWrites++
-	expectedStats.BandwidthRegWrites += skynet.CostBandwidthRegistryWrite
-
 	// Call userStats without a cookie.
 	at.ClearCredentials()
 	_, _, err = at.UserStats("", nil)


### PR DESCRIPTION
# PULL REQUEST

## Overview

As we have high priority work that trumps DB performance tracking and optimisations, we wanted to have some quick wins before we park this effort. This PR provides those quick wins by removing registry tracking.

What's done here: Stop tracking registry accesses and drop all DB collections related to those.

## Example for Visual Changes
<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist
Review and complete the checklist to ensure that the PR is complete before assigned to an approver.
 - [ ] All new methods or updated methods have clear docstrings
 - [ ] Testing added or updated for new methods
 - [ ] Verify if any changes impact the WebPortal Health Checks
 - [ ] Approriate documentation updated
 - [ ] Changelog file created

## Issues Closed
<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
