### PR TITLE
Fix Stripe duplicate sub canceling.

### DIFF
--- a/api/stripe_test.go
+++ b/api/stripe_test.go
@@ -1,0 +1,40 @@
+package api
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stripe/stripe-go/v72"
+)
+
+// TestStripePrices ensures that we work with the correct set of prices.
+func TestStripePrices(t *testing.T) {
+	// Set the Stripe key to a live key.
+	stripe.Key = "sk_live_FAKE_LIVE_KEY"
+	// Make sure we got the prod prices we expect.
+	if !reflect.DeepEqual(StripePrices(), stripePricesProd) {
+		t.Fatal("Expected prod prices, got something else.")
+	}
+	// Set the Stripe key to a test key.
+	stripe.Key = "sk_test_FAKE_TEST_KEY"
+	// Make sure we got the prod prices we expect.
+	if !reflect.DeepEqual(StripePrices(), stripePricesTest) {
+		t.Fatal("Expected test prices, got something else.")
+	}
+}
+
+// TestStripeTestMode ensures that we detect test mode accurately.
+func TestStripeTestMode(t *testing.T) {
+	// Set the Stripe key to a live key.
+	stripe.Key = "sk_live_FAKE_LIVE_KEY"
+	// Expect test mode to be off.
+	if StripeTestMode() {
+		t.Fatal("Expected live mode, got test mode.")
+	}
+	// Set the Stripe key to a test key.
+	stripe.Key = "sk_test_FAKE_TEST_KEY"
+	// Expect test mode to be on.
+	if !StripeTestMode() {
+		t.Fatal("Expected test mode, got live mode.")
+	}
+}

--- a/build/debug_off.go
+++ b/build/debug_off.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package build

--- a/build/debug_on.go
+++ b/build/debug_on.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package build

--- a/build/release_dev.go
+++ b/build/release_dev.go
@@ -1,3 +1,4 @@
+//go:build dev
 // +build dev
 
 package build

--- a/build/release_standard.go
+++ b/build/release_standard.go
@@ -1,3 +1,4 @@
+//go:build !testing && !dev
 // +build !testing,!dev
 
 package build

--- a/build/release_testing.go
+++ b/build/release_testing.go
@@ -1,3 +1,4 @@
+//go:build testing
 // +build testing
 
 package build

--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/SkynetLabs/skynet-accounts/api"
 	"github.com/SkynetLabs/skynet-accounts/build"
@@ -70,7 +69,6 @@ type (
 		PortalAddressAccounts string
 		ServerLockID          string
 		StripeKey             string
-		StripeTestMode        bool
 		JWKSFile              string
 		JWTTTL                int
 		EmailURI              string
@@ -145,7 +143,6 @@ func parseConfiguration(logger *logrus.Logger) (ServiceConfig, error) {
 
 	if sk := os.Getenv(envStripeAPIKey); sk != "" {
 		config.StripeKey = sk
-		config.StripeTestMode = !strings.HasPrefix(sk, "sk_live_")
 	}
 	if jwks := os.Getenv(envAccountsJWKSFile); jwks != "" {
 		config.JWKSFile = jwks
@@ -231,7 +228,6 @@ func main() {
 	api.DashboardURL = config.PortalAddressAccounts
 	email.ServerLockID = config.ServerLockID
 	stripe.Key = config.StripeKey
-	api.StripeTestMode = config.StripeTestMode
 	jwt.AccountsJWKSFile = config.JWKSFile
 	jwt.TTL = config.JWTTTL
 	email.From = config.EmailFrom

--- a/main_test.go
+++ b/main_test.go
@@ -190,9 +190,6 @@ func TestParseConfiguration(t *testing.T) {
 	if config.StripeKey != sk {
 		t.Fatalf("Expected %s, got %s", sk, config.StripeKey)
 	}
-	if config.StripeTestMode {
-		t.Fatal("Expected live mode.")
-	}
 	if config.ServerLockID != serverDomain {
 		t.Fatalf("Expected %s, got %s", serverDomain, config.ServerLockID)
 	}
@@ -226,9 +223,6 @@ func TestParseConfiguration(t *testing.T) {
 	}
 	if config.StripeKey != sk {
 		t.Fatalf("Expected %s, got %s", sk, config.StripeKey)
-	}
-	if !config.StripeTestMode {
-		t.Fatal("Expected test mode.")
 	}
 	if config.MaxAPIKeys != maxKeys {
 		t.Fatalf("Expected %d, got %d", maxKeys, config.MaxAPIKeys)

--- a/test/api/stripe_test.go
+++ b/test/api/stripe_test.go
@@ -32,7 +32,6 @@ func TestStripe(t *testing.T) {
 			"Expected STRIPE_API_KEY that starts with '%s', got '%s'", t.Name(), "sk_test_", key[:8])
 	}
 	stripe.Key = key
-	api.StripeTestMode = true
 
 	tests := map[string]func(t *testing.T, at *test.AccountsTester){
 		"get billing":   testStripeBillingGET,


### PR DESCRIPTION
# PULL REQUEST

## Overview

This PR fixes a problem with our ability to cancel subscriptions for users. We want to be able to do that, so if a user manages to create two subscriptions in parallel, we can cancel the earlier one in order to not charge them twice.  
This code has been in there forever but apparently didn't work properly. It's an [old](https://github.com/cartalyst/stripe/issues/84) peculiarity of Stripe's service.

The PR is a bit longer than it needs to because touching this part of the code allowed me to clean it up a little bit. I'll mark the relevant section.

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [ ] All git commits are signed. (REQUIRED)
- [ ] All new methods or updated methods have clear docstrings.
- [ ] Testing added or updated for new methods.
- [ ] Verified if any changes impact the WebPortal Health Checks.
- [ ] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
