### PR TITLE
Increase timeout for generating env, jwks.json files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ docker-generate: clean
 	@mkdir output
 	@docker build -f ./env/Dockerfile -t accounts-genenv .
 	@docker run -v ${PWD}/output:/app --name genenv -d accounts-genenv
-	sleep 3
+	sleep 10
 	@docker stop genenv || true && docker rm --force genenv
 
 .PHONY: all deps fmt install release clean check test test-long test-long-ci start-mongo stop-mongo docker-generate


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

IMPORTANT:
Before continuing, please make sure that ALL your commits are signed!
- Setting up signing commits:
  https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits
- Signing existing commits:
  https://superuser.com/a/1123928/664691
- If that doesn't work, squash your commits and force push one signed commit.
-->

# PULL REQUEST

## Overview

Executing `make docker-generate` sometimes doesn't create `jwks.json` and sometimes it creates empty file.
This PR updates sleep timeout for file creation so that generating the file via Ansible is more reliable.

<!--
Provide a detailed description of the change.
-->

## Example for Visual Changes

<!--
For user facing features please provide proof that the format is as expected.
Screen shots and/or asciinema recordings are very helpful.
-->

## Checklist

<!--
Review and complete the checklist to ensure that the PR is complete before
assigned to an approver. Leave blank any that you are unsure about.
-->

- [x] All git commits are signed. (REQUIRED)
- [x] All new methods or updated methods have clear docstrings.
- [x] Testing added or updated for new methods.
- [x] Verified if any changes impact the WebPortal Health Checks.
- [x] Appropriate documentation updated.
- [ ] Changelog file created.

## Issues Closed

<!--
Use the `Closes` keyword to automatically close the issue on merge.
Example: Closes #XXXX
-->
